### PR TITLE
Fix PAE and pCMAP order of residues pairs

### DIFF
--- a/docs/run_input_output.md
+++ b/docs/run_input_output.md
@@ -176,7 +176,7 @@ It includes the following fields:
 - **C_pos**: List of protein positions of the gene clusters.
 - **C_label**: List of labels indicating the clump to which each cluster is grouped.
 - **Pos_top_vol**: Position of the most significant cluster.
-- **Score_obs_sim_top_vol**: 3D clustering score of the gene (normalized 3D clustering score of the residue with the lowest p-value; if multiple residues have the same lowest p-value, the maximum normalized 3D clustering score among those residues is used).
+- **Score_obs_sim_top_vol**: 3D clustering score of the gene (rescaled 3D clustering score of the residue with the lowest p-value; if multiple residues have the same lowest p-value, the maximum rescaled 3D clustering score among those residues is used).
 - **Mut_in_gene**: Number of missense mutations in the gene.
 - **Clust_mut**: Number of missense mutations in significant clusters.
 - **Clust_res**: Number of residues detected as significant clusters.
@@ -227,12 +227,12 @@ It includes the following fields:
 - **Mut_in_res**: Number of missense mutations in the residue.
 - **Mut_in_vol**: Number of missense mutations in the volume of the residue.
 - **Score**: 3D clustering score for the residue.
-- **Score_obs_sim**: Normalized 3D clustering score for the residue.
+- **Score_obs_sim**: Rescaled 3D clustering score for the residue.
 - **pval**: The p-value of the residue in the 3D clustering analysis.
 - **C**: Binary label indicating whether the cluster at that residue is significant (1) or not (0). A cluster is marked as significant either because it meets the significance criteria directly or because it has been rescued by contributing mutations to another significant cluster.
 - **C_ext**: Binary label indicating whether the cluster has been rescued by contributing mutations to another significant cluster (1) or if it was significant on its own (0).
 - **Clump**: Identifier for the clump to which the cluster at that residue has been assigned.
-- **Rank**: Rank used to perform the calculation of the normalized 3D clustering score and p-values. 
+- **Rank**: Rank used to perform the calculation of the 3D clustering score and p-values. 
 - **Mut_in_cl_vol**: Number of missense mutations in the clusters of the clump to which the cluster has been assigned.
 - **Res_in_cl**: Positions of the clusters of the clump to which the cluster has been assigned.
 - **PAE_vol**: Weighted average predicted aligned error (PAE) of the residues in the volume of the cluster.

--- a/scripts/datasets/prob_contact_maps.py
+++ b/scripts/datasets/prob_contact_maps.py
@@ -162,7 +162,7 @@ def get_prob_cmap(chain, pae, distance=10) :
     for i, res1 in enumerate(chain):
         for j, res2 in enumerate(chain):
             d = abs(res1["CA"] - res2["CA"])
-            m[i, j] = get_prob_contact(pae[i, j], d, distance)
+            m[i, j] = get_prob_contact(pae[j, i], d, distance)
 
     return m
 

--- a/scripts/datasets/prob_contact_maps.py
+++ b/scripts/datasets/prob_contact_maps.py
@@ -199,10 +199,16 @@ def get_prob_cmaps(pdb_files, pae_path, output_path, distance=10, num_process=0)
         # Get probabilistic CMAP
         else:
             try:
-                pae = np.load(os.path.join(pae_path, f"{identifier}-predicted_aligned_error.npy"))
+                pae_path_id = os.path.join(pae_path, f"{identifier}-predicted_aligned_error.npy")
                 chain = get_structure(file)["A"]
-                prob_cmap = get_prob_cmap(chain, pae, distance=distance)
-                np.save(os.path.join(output_path, f"{identifier}.npy"), prob_cmap)
+                if os.path.exists(pae_path_id):
+                    pae = np.load(pae_path_id)
+                    prob_cmap = get_prob_cmap(chain, pae, distance=distance)
+                    np.save(os.path.join(output_path, f"{identifier}.npy"), prob_cmap)
+                else:
+                    logger.warning(f"Processing cMAP without PAE for {identifier}")
+                    cmap = get_contact_map(chain, distance=distance)
+                    np.save(os.path.join(output_path, f"{identifier}.npy"), cmap)
             except Exception as e:
                 logger.warning(f"Could not process {identifier}")
                 logger.warning(f"Error: {e}")


### PR DESCRIPTION
The PR fix the order of residues used to select elements in the PAE object, as explained in #53 

- Fix the order of residue
- Allows to compute pCMAP for not fragmented structures without available PAE
- Update input and output documentation (changed "normalized" to "rescaled")