### PR TITLE
Add MANE‑Only and MANE custom predicted structures

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN mkdir -p /root/.cache/uv \
     && uv build
 
 # Second stage: Runtime image
-FROM python:3.10-buster AS runtime-stage
+FROM python:3.10.18-bookworm AS runtime-stage
 
 # Set environment variables
 ENV BGDATA_LOCAL="/bgdatacache" \

--- a/README.md
+++ b/README.md
@@ -86,7 +86,10 @@ Options:
                                   (applicable to Homo sapiens only).
   -M, --mane_only                 Use only structures predicted from MANE Select transcripts
                                   (applicable to Homo sapiens only).
-  -C, --custom_pdb_dir            Load custom structures from directory (overwriting existing ones).
+  -C, --custom_mane_pdb_dir       Path to directory containing custom MANE PDB structures.
+                                  Default: None
+  -f, --custom_mane_metadata_path Path to a dataframe (typically a samplesheet.csv) including 
+                                  Ensembl IDs and sequences of the custom pdbs.
   -d, --distance_threshold INT    Distance threshold (Å) for defining residues contacts. 
                                   Default: 10
   -c, --cores INT                 Number of CPU cores for computation. 
@@ -96,6 +99,25 @@ Options:
 ```
 
 For more information on the output of this step, please refer to the [Building Datasets Output Documentation](https://github.com/bbglab/oncodrive3d/tree/master/docs/build_output.md).
+
+> [!TIP]
+> ### Increasing MANE Structural Coverage
+> To maximize structural coverage of **MANE Select transcripts**, you can predict missing structures locally and integrate them into Oncodrive3D using:
+>
+> - `tools/preprocessing/prepare_samplesheet.py`: a standalone utility that:
+>   - Retrieve the full MANE entries from NCBI.
+>   - Identifies proteins missing from the AlphaFold MANE dataset.
+>   - Generates:
+>     - A `samplesheet.csv` with Ensembl protein IDs, FASTA paths, and optional sequences.
+>     - Individual FASTA files for each missing protein.
+>
+> - `--custom_mane_pdb_dir`: use this to provide your own predicted PDB structures (e.g., from [nf-core/proteinfold](https://nf-co.re/proteinfold/1.0.0/)).
+>
+> - `--custom_mane_metadata_path`: path to the corresponding `samplesheet.csv`, which must include:
+>   - `sequence`: Ensembl protein ID (required)
+>   - `refseq`: amino acid sequence (used to inject sequence into PDB if missing)
+>
+
 
 
 ## Running 3D clustering Analysis

--- a/docs/build_output.md
+++ b/docs/build_output.md
@@ -2,12 +2,18 @@
 
 After successfully completing this step, the build folder must include the following files and directories:
 
-- **pae/**: directory including the AlphaFold predicted aligned error (PAE) for any protein of the proteome with a length lower than 2700 amino acids
+- **pae/**: Directory including the AlphaFold predicted aligned error (PAE) for any protein of the proteome with a length lower than 2700 amino acids
 
-- **prob_cmaps/**: directory including the contact probability map (pCMAPs) for any protein of the proteome
+- **prob_cmaps/**: Directory including the contact probability map (pCMAPs) for any protein of the proteome
 
 - **confidence.csv**: CSV file including per-residue predicted local distance difference test (pLDDT) score for any protein of the proteome
 
 - **seq_for_mut_prob.csv**: CSV file including HUGO symbol, Uniprot ID, DNA and protein sequences for any proteine of the proteome
+
+- **pdb_structures/**: Directory containing all PDB structure files—both those downloaded from the AlphaFold database and any custom in-house predicted structures (if provided).
+
+- **log/**: Directory containing log files produced during the build-datasets execution.
+
+- **biomart_metadata.csv**: Metadata file from Ensembl BioMart used to prioritize canonical transcripts when multiple transcripts map to the same protein structure.
 
 ...

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,2 +1,2 @@
 __logger_name__ = 'oncodrive3d'
-__version__ = "1.0.5"
+__version__ = "1.0.6"

--- a/scripts/datasets/build_datasets.py
+++ b/scripts/datasets/build_datasets.py
@@ -161,12 +161,12 @@ def build(output_datasets,
 
 if __name__ == "__main__":
     build(
-      output_datasets="/data/bbg/nobackup/scratch/oncodrive3d/tests/datasets_mane_230725_mane_missing_dev",
+      output_datasets="/data/bbg/nobackup/scratch/oncodrive3d/tests/datasets_mane_240725_mane_missing_dev",
       organism="Homo sapiens",
       mane=False,
       mane_only=True,
-      custom_pdb_dir="/data/bbg/nobackup/scratch/oncodrive3d/mane_missing/af2_predictions/20250604_prediction_all_20250619_copy/alphafold2/standard",
-      custom_fasta_dir="/data/bbg/nobackup/scratch/oncodrive3d/mane_missing/preprocessing/data/fasta",
+      custom_pdb_dir="/data/bbg/nobackup/scratch/oncodrive3d/mane_missing/data/250724-no_fragments/af_predictions/previously_pred",
+      custom_mane_metadata_path="/data/bbg/nobackup/scratch/oncodrive3d/mane_missing/data/250724-no_fragments/af_predictions/previously_pred/samplesheet.csv",
       distance_threshold=10,
       num_cores=8,
       af_version=4,

--- a/scripts/datasets/build_datasets.py
+++ b/scripts/datasets/build_datasets.py
@@ -57,9 +57,7 @@ def build(output_datasets,
 
     # Download PDB structures
     species = get_species(organism)
-    if mane_only:
-      mane = True
-    else:
+    if not mane_only:
       logger.info("Downloading AlphaFold (AF) predicted structures...")
       get_structures(
         path=os.path.join(output_datasets,"pdb_structures"),
@@ -115,7 +113,8 @@ def build(output_datasets,
       organism=species,
       mane=mane,
       num_cores=num_cores,
-      mane_version=mane_version
+      mane_version=mane_version,
+      custom_mane_metadata_path=custom_mane_metadata_path
       )
     logger.info("Generation of sequences dataframe completed!")
 
@@ -161,7 +160,7 @@ def build(output_datasets,
 
 if __name__ == "__main__":
     build(
-      output_datasets="/data/bbg/nobackup/scratch/oncodrive3d/tests/datasets_mane_240725_mane_missing_dev",
+      output_datasets="/data/bbg/nobackup/scratch/oncodrive3d/tests/datasets_mane_250725_mane_missing_dev",
       organism="Homo sapiens",
       mane=False,
       mane_only=True,

--- a/scripts/datasets/build_datasets.py
+++ b/scripts/datasets/build_datasets.py
@@ -43,7 +43,7 @@ def build(output_datasets,
           mane,
           mane_only,
           custom_pdb_dir,
-          custom_fasta_dir,
+          custom_mane_metadata_path,
           distance_threshold,
           num_cores,
           af_version,
@@ -87,13 +87,21 @@ def build(output_datasets,
         
     # Copy custom PDB structures and optinally add SEQRES
     if custom_pdb_dir is not None:
+      if custom_mane_metadata_path is None:
+        logger.error(
+          "custom_mane_metadata_path must be provided when custom_pdb_dir is specified"
+          )
+        raise ValueError(
+          "Both custom_pdb_dir and custom_mane_metadata_path must be provided together"
+          )
+      
       logger.info("Copying custom PDB structures...")
       if os.path.exists(custom_pdb_dir):
         copy_and_parse_custom_pdbs(
           src_dir=custom_pdb_dir,
           dst_dir=os.path.join(output_datasets,"pdb_structures"), 
           af_version=int(af_version),
-          fasta_dir=custom_fasta_dir
+          custom_mane_metadata_path=custom_mane_metadata_path
           )
       else:
           logger.error(f"Custom PDB directory does not exist: {custom_pdb_dir}")
@@ -153,11 +161,14 @@ def build(output_datasets,
 
 if __name__ == "__main__":
     build(
-      output_datasets="/workspace/nobackup/scratch/oncodrive3d/datasets_mane",
+      output_datasets="/data/bbg/nobackup/scratch/oncodrive3d/tests/datasets_mane_230725_mane_missing_dev",
       organism="Homo sapiens",
-      mane=True,
+      mane=False,
+      mane_only=True,
+      custom_pdb_dir="/data/bbg/nobackup/scratch/oncodrive3d/mane_missing/af2_predictions/20250604_prediction_all_20250619_copy/alphafold2/standard",
+      custom_fasta_dir="/data/bbg/nobackup/scratch/oncodrive3d/mane_missing/preprocessing/data/fasta",
       distance_threshold=10,
       num_cores=8,
       af_version=4,
-      mane_version=1.3
+      mane_version=1.4
       )

--- a/scripts/datasets/custom_pdb.py
+++ b/scripts/datasets/custom_pdb.py
@@ -138,7 +138,7 @@ def copy_and_parse_custom_pdbs(
                     if not pd.isna(seq):
                         logger.debug(f"SEQRES record already present in the structure: {new_name}")
                     else:
-                        logger.warning(f"SEQRES record not in samplesheet and could not extract it from the structure: {new_name}")
+                        logger.warning(f"SEQRES not found in samplesheet and its extraction from structure failed: {new_name}")
                 except Exception as e:
-                    logger.warning(f"SEQRES record not in samplesheet and could not extract it from the structure: {new_name}")
+                    logger.warning(f"SEQRES not found in samplesheet and its extraction from structure failed: {new_name}")
                     logger.warning(f"Exception captured: {e}")

--- a/scripts/datasets/custom_pdb.py
+++ b/scripts/datasets/custom_pdb.py
@@ -2,6 +2,7 @@ import os
 import gzip
 import shutil
 import daiquiri
+import pandas as pd
 
 from scripts import __logger_name__
 
@@ -120,11 +121,11 @@ def copy_and_parse_custom_pdbs(
         logger.debug(f'Copied and gzipped: {fname} -> {new_name}')
         
         # Optionally add SEQRES records
-        if samplesheet_df:
+        if samplesheet_df is not None:
             if accession not in samplesheet_df["sequence"].values:
                 logger.warning("Accession %s not in samplesheet %s", accession, custom_mane_metadata_path)
                 continue
-            seq = samplesheet_df[samplesheet_df["sequence"] == accession].refseq[0]
+            seq = samplesheet_df[samplesheet_df["sequence"] == accession].refseq.values[0]
             seq = [one_to_three_res_map[aa] for aa in seq]
             add_seqres_to_pdb(dst_path, seq)
             logger.debug("Inserted SEQRES records into: %s", dst_path)

--- a/scripts/datasets/custom_pdb.py
+++ b/scripts/datasets/custom_pdb.py
@@ -3,6 +3,7 @@ import gzip
 import shutil
 import daiquiri
 import pandas as pd
+from scripts.datasets.utils import get_seq_from_pdb
 
 from scripts import __logger_name__
 
@@ -127,14 +128,17 @@ def copy_and_parse_custom_pdbs(
                 continue
             seq = samplesheet_df[samplesheet_df["sequence"] == accession].refseq.values[0]
             
-            if not np.isnan(seq):
+            if not pd.isna(seq):
                 seq = [one_to_three_res_map[aa] for aa in seq]
                 add_seqres_to_pdb(path_pdb=dst_path, residues=seq)
-                logger.debug("Inserted SEQRES records into: %s", dst_path)
+                logger.debug(f"Inserted SEQRES records into: {new_name}")
             else:
                 try:
                     seq = "".join(list(get_seq_from_pdb(dst_path)))
-                    logger.debug("SEQRES record already present in the structure: %s", dst_path)
+                    if not pd.isna(seq):
+                        logger.debug(f"SEQRES record already present in the structure: {new_name}")
+                    else:
+                        logger.warning(f"SEQRES record not in samplesheet and could not extract it from the structure: {new_name}")
                 except Exception as e:
-                    logger.warning("SEQRES record not in samplesheet and not already in the structure")
+                    logger.warning(f"SEQRES record not in samplesheet and could not extract it from the structure: {new_name}")
                     logger.warning(f"Exception captured: {e}")

--- a/scripts/datasets/custom_pdb.py
+++ b/scripts/datasets/custom_pdb.py
@@ -126,6 +126,15 @@ def copy_and_parse_custom_pdbs(
                 logger.warning("Accession %s not in samplesheet %s", accession, custom_mane_metadata_path)
                 continue
             seq = samplesheet_df[samplesheet_df["sequence"] == accession].refseq.values[0]
-            seq = [one_to_three_res_map[aa] for aa in seq]
-            add_seqres_to_pdb(dst_path, seq)
-            logger.debug("Inserted SEQRES records into: %s", dst_path)
+            
+            if not np.isnan(seq):
+                seq = [one_to_three_res_map[aa] for aa in seq]
+                add_seqres_to_pdb(path_pdb=dst_path, residues=seq)
+                logger.debug("Inserted SEQRES records into: %s", dst_path)
+            else:
+                try:
+                    seq = "".join(list(get_seq_from_pdb(dst_path)))
+                    logger.debug("SEQRES record already present in the structure: %s", dst_path)
+                except Exception as e:
+                    logger.warning("SEQRES record not in samplesheet and not already in the structure")
+                    logger.warning(f"Exception captured: {e}")

--- a/scripts/datasets/get_pae.py
+++ b/scripts/datasets/get_pae.py
@@ -80,13 +80,13 @@ def get_pae(
         logger.debug("PAE already downloaded: Skipping...")
         return
     
-    # Do not download PAE of custom provided structures
-    if custom_pdb_dir is not None:
-        custom_uniprot_ids = [fname.split('.')[0] for fname in os.listdir(custom_pdb_dir) if fname.endswith('.pdb')]
-
     pdb_files = [file for file in os.listdir(input_dir) if file.startswith("AF-") and file.endswith(f"-model_v{af_version}.pdb.gz")]
     uniprot_ids = [pdb_file.split("-")[1] for pdb_file in pdb_files]
-    uniprot_ids = [uni_id for uni_id in uniprot_ids if uni_id not in custom_uniprot_ids]
+    
+    # Do not download PAE for custom provided structures
+    if custom_pdb_dir is not None:
+        custom_uniprot_ids = [fname.split('.')[0] for fname in os.listdir(custom_pdb_dir) if fname.endswith('.pdb')]
+        uniprot_ids = [uni_id for uni_id in uniprot_ids if uni_id not in custom_uniprot_ids]
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=num_cores) as executor:
         tasks = [executor.submit(download_pae, uniprot_id, af_version, output_dir) for uniprot_id in uniprot_ids]

--- a/scripts/datasets/prob_contact_maps.py
+++ b/scripts/datasets/prob_contact_maps.py
@@ -206,7 +206,7 @@ def get_prob_cmaps(pdb_files, pae_path, output_path, distance=10, num_process=0)
                     prob_cmap = get_prob_cmap(chain, pae, distance=distance)
                     np.save(os.path.join(output_path, f"{identifier}.npy"), prob_cmap)
                 else:
-                    logger.warning(f"Processing cMAP without PAE for {identifier}")
+                    logger.debug(f"Processing cMAP without PAE for {identifier}")
                     cmap = get_contact_map(chain, distance=distance)
                     np.save(os.path.join(output_path, f"{identifier}.npy"), cmap)
             except Exception as e:

--- a/scripts/datasets/seq_for_mut_prob.py
+++ b/scripts/datasets/seq_for_mut_prob.py
@@ -1005,9 +1005,7 @@ def get_seq_df(datasets_dir,
                                 uniprot_to_gene_dict,
                                 ens_canonical_transcripts_lst,
                                 num_cores,
-                                rm_weird_chr,
                                 mane_version=mane_version)
-
 
     # Save
     seq_df_cols = ['Gene', 'HGNC_ID', 'Ens_Gene_ID',

--- a/scripts/datasets/seq_for_mut_prob.py
+++ b/scripts/datasets/seq_for_mut_prob.py
@@ -1004,8 +1004,7 @@ def get_seq_df(datasets_dir,
                                 organism,
                                 uniprot_to_gene_dict,
                                 ens_canonical_transcripts_lst,
-                                num_cores,
-                                mane_version=mane_version)
+                                num_cores)
 
     # Save
     seq_df_cols = ['Gene', 'HGNC_ID', 'Ens_Gene_ID',

--- a/scripts/datasets/seq_for_mut_prob.py
+++ b/scripts/datasets/seq_for_mut_prob.py
@@ -557,7 +557,7 @@ def get_mane_to_af_mapping(
                                             "uniprot_accession" : "Uniprot_ID"}).drop(columns=["alphafold"])
     path_mane_summary = os.path.join(datasets_dir, "mane_summary.txt.gz")
     if not os.path.exists(path_mane_summary):
-        download_mane_summary(path_mane_summary, mane_version, cores)
+        download_mane_summary(path_mane_summary, mane_version, cores=cores)
 
     mane_summary = pd.read_csv(path_mane_summary, compression='gzip', sep="\t")
     

--- a/scripts/datasets/seq_for_mut_prob.py
+++ b/scripts/datasets/seq_for_mut_prob.py
@@ -2,17 +2,12 @@
 Module to generate a pandas dataframe including identifiers 
 mapped to protein and DNA sequences.
 
-The functions are used to extract all protein sequences of 
-PDB structures in a given directory; use EMBOSS backtranseq 
-to back translate proteins sequences into DNA; generate a 
-dataframe including HUGO symbol, Uniprot_ID, protein, and 
-DNA sequences. This dataframe is required to get the 
-probability of each residue to mutate (missense mutation) 
-based on the mutation profile (mutation rate in 96 
-trinucleotide contexts) of the cohort. The per-residue 
-missense mutation probability of each protein is then used 
-to get the probability of a certain volume to be hit by a 
-missense mutation.
+This dataframe is required to get the probability of each 
+residue to mutate (missense mutation) based on the mutation 
+profile (mutation rate in 96 trinucleotide contexts) of the 
+cohort. The per-residue missense mutation probability of 
+each protein is then used to get the probability of a 
+certain volume to be hit by a missense mutation.
 """
 
 
@@ -774,35 +769,6 @@ def drop_gene_duplicates(df):
     return df
 
 
-# def mane_ensprot_to_hugo(
-#     ens_prot_ids,
-#     datasets_dir,
-#     prot_col='Ensembl_prot',
-#     hugo_col='symbol',
-#     strip_version=True
-#     ):
-#     """
-#     Generate a mapping from Ensembl protein IDs to gene symbols.
-#     """
-    
-#     # Load MANE summary
-#     path_mane_summary = os.path.join(datasets_dir, "mane_summary.txt.gz")
-#     if not os.path.exists(path_mane_summary):
-#         download_mane_summary(path_mane_summary, mane_version)
-#     mane_summary = pd.read_csv(path_mane_summary, compression='gzip', sep="\t").dropna(
-#         subset=["symbol", prot_col]
-#         )
-    
-#     # Remove suffix
-#     if strip_version:
-#         mane_summary[prot_col] = mane_summary[prot_col].str.replace(r'\.\d+$', '', regex=True)
-
-#     # Filter and select only the two columns we need
-#     sel = mane_summary.loc[mane_summary[prot_col].isin(ens_prot_ids),[prot_col, hugo_col]]
-
-#     return dict(zip(sel[prot_col], sel[hugo_col]))
-
-
 def mane_uniprot_to_hugo(uniprot_ids, mane_mapping):
     """
     Generate a mapping from Uniprot IDs to Hugo Symbols for MANE 
@@ -1006,12 +972,6 @@ def get_seq_df(datasets_dir,
         uniprot_to_gene_dict = uniprot_to_gene_dict | uniprot_to_hugo(missing_uni_ids)
     else:
         uniprot_to_gene_dict = uniprot_to_hugo(uniprot_ids)
-    
-    # # Check for Ensembl Protein IDs (custom predicted structures)
-    # ens_prot_ids = [uni_id for uni_id in uniprot_ids if uni_id.startswith("ENSP")]
-    # if ens_prot_ids:
-    #     ensprot_to_gene_dict = mane_ensprot_to_hugo(ens_prot_ids, datasets_dir)
-    #     uniprot_to_gene_dict = uniprot_to_gene_dict | ensprot_to_gene_dict
     
     # ---
     # # Workaround if the direct request to UniprotKB stops working (it has happened temporarily)

--- a/scripts/datasets/seq_for_mut_prob.py
+++ b/scripts/datasets/seq_for_mut_prob.py
@@ -460,7 +460,7 @@ def add_extra_genes_to_seq_df(seq_df, uniprot_to_gene_dict):
     return seq_df
 
 
-def download_mane_summary(path_to_file, v=1.3, max_attempts=15):
+def download_mane_summary(path_to_file, v=1.3, max_attempts=15, cores=1):
     """
     Download the summary.txt of the MANE release from NCBI.
     """
@@ -469,25 +469,38 @@ def download_mane_summary(path_to_file, v=1.3, max_attempts=15):
     attempts = 0
 
     while not os.path.exists(path_to_file):
-        download_single_file(mane_summary_url, path_to_file, threads=1)
+        download_single_file(mane_summary_url, path_to_file, threads=cores)
         attempts += 1
         if attempts >= max_attempts:
             raise RuntimeError(f"Failed to download MANE summary file after {max_attempts} attempts. Exiting..")
         time.sleep(5)
 
 
-def select_uni_id(ids_tuple, all_ids):
+def select_uni_id(df, uniprot_ids):
     """
-    Return the first Uniprot ID present in the list of IDs
-    (list of structures available). If no ID of the tuple
-    maps a downloaded structure, return NA.
+    For each row in `df`, normalize its 'Uniprot_ID' field—whether a single ID string
+    or a semicolon-separated list—by selecting the first ID that exists in `available_ids`.
+    If no IDs match, returns NaN for that row.
     """
+    
+    if sum(df.Uniprot_ID.str.split(";").apply(lambda x: len(x)) > 1) == 0:
+        return df
+        
+    out = df.copy()
+    
+    def pick_first(uid_val):
 
-    for uni_id in ids_tuple:
-        if uni_id in all_ids:
-            return uni_id
+        if pd.isna(uid_val):
+            return np.nan
+        
+        # Split on ';' always: single IDs become a single-element list
+        ids = str(uid_val).split(';')
+        
+        # Return first match or NaN
+        return next((uid for uid in ids if uid in set(uniprot_ids)), np.nan)
 
-    return np.nan
+    out['Uniprot_ID'] = out['Uniprot_ID'].apply(pick_first)
+    return out
 
 
 def load_custom_ens_prot_ids(path):
@@ -500,7 +513,7 @@ def load_custom_ens_prot_ids(path):
         raise FileNotFoundError(f"Custom PDB metadata not found: {path!r}")
     df = pd.read_csv(path)
     ids = (
-        df["Ens_Prot_ID"]
+        df["sequence"]
         .astype(str)
         .str.split(".", n=1)
         .str[0]
@@ -513,10 +526,12 @@ def load_custom_ens_prot_ids(path):
 
 def get_mane_to_af_mapping(
     datasets_dir, 
-    downloaded_uniprot_ids, 
+    uniprot_ids, 
     include_not_af=False, 
     mane_version=1.4,
-    custom_mane_metadata_path=None):
+    custom_mane_metadata_path=None, 
+    cores=1
+    ):
     """
     Get a dataframe to map genes, MANE transcript IDs, and AlphaFold structures.
     If custom_mane_metadata_path is provided, the Ensembl protein IDs within the 
@@ -526,7 +541,7 @@ def get_mane_to_af_mapping(
     ----------
     datasets_dir : str
         Root folder where MANE and UniProt files live.
-    downloaded_uniprot_ids : set
+    uniprot_ids : set
         UniProt accessions already downloaded locally (used to pick among multiples).
     include_not_af : bool, default False
         If True, also return MANE entries without AlphaFold models.
@@ -547,13 +562,9 @@ def get_mane_to_af_mapping(
                                             "uniprot_accession" : "Uniprot_ID"}).drop(columns=["alphafold"])
     path_mane_summary = os.path.join(datasets_dir, "mane_summary.txt.gz")
     if not os.path.exists(path_mane_summary):
-        download_mane_summary(path_mane_summary, mane_version)
+        download_mane_summary(path_mane_summary, mane_version, cores)
 
-    mane_summary = pd.read_csv(
-        path_mane_summary, 
-        compression='gzip', 
-        sep="\t"
-        ).dropna(subset=["symbol", "HGNC_ID"])
+    mane_summary = pd.read_csv(path_mane_summary, compression='gzip', sep="\t")
     
     mane_summary = mane_summary.rename(columns={
         "symbol" : "Gene",
@@ -575,16 +586,10 @@ def get_mane_to_af_mapping(
         "Reverse_strand"
         ]]
     
-    mane_mapping = mane_to_af.merge(mane_summary, how="left", on="Refseq_prot").dropna()
+    mane_mapping = mane_summary.merge(mane_to_af, how="left", on="Refseq_prot")
     mane_mapping.Reverse_strand = mane_mapping.Reverse_strand.map({"+" : 0, "-" : 1})
     mane_mapping.Ens_Gene_ID = mane_mapping.Ens_Gene_ID.apply(lambda x: x.split(".")[0])
     mane_mapping.Ens_Transcr_ID = mane_mapping.Ens_Transcr_ID.apply(lambda x: x.split(".")[0])
-
-    # Select first Uniprot ID if multiple ones are present
-    mane_mapping["Uniprot_ID"] = mane_mapping.apply(lambda x:
-                                            select_uni_id(x.Uniprot_ID.split(";"), downloaded_uniprot_ids) if len(x.Uniprot_ID.split(";")) > 1
-                                            else x.Uniprot_ID, axis=1)
-    mane_mapping = mane_mapping.reset_index(drop=True)
 
     # Override Uniprot_ID with Ens_Prot_ID for the custom PDB structures
     if custom_mane_metadata_path is not None:
@@ -593,13 +598,35 @@ def get_mane_to_af_mapping(
         mask = base_ens.isin(custom_ids)
         mane_mapping.loc[mask, "Uniprot_ID"] = base_ens[mask]
 
+    # Select available Uniprot ID, fist one if multiple are present
+    mane_mapping = mane_mapping.dropna(subset=["Uniprot_ID"]).reset_index(drop=True)
+    mane_mapping = select_uni_id(mane_mapping, uniprot_ids)
+    mane_mapping = mane_mapping[mane_mapping["Uniprot_ID"].isin(uniprot_ids)]
+
     # Also return a dataframe with entries not in AF
     if include_not_af:
-        mane_not_af = mane[~mane.Gene.isin(mane_mapping.Gene)].reset_index(drop=True)
+        mane_not_af = mane_summary[~mane_summary.Gene.isin(mane_mapping.Gene)].reset_index(drop=True)
         return mane_mapping, mane_not_af
 
     else:
         return mane_mapping
+
+
+# def download_biomart_metadata(path_to_file, max_attempts=15, cores=8):
+#     """
+#         Query biomart to get the list of transcript corresponding to the downloaded
+#     structures (a few structures are missing) and other information.
+#     """
+
+#     url = 'http://jan2024.archive.ensembl.org/biomart/martservice?query=<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE Query><Query virtualSchemaName="default" formatter="TSV" header="0" uniqueRows="0" count="" datasetConfigVersion="0.6"><Dataset name="hsapiens_gene_ensembl" interface="default"><Attribute name="ensembl_gene_id"/><Attribute name="ensembl_transcript_id"/><Attribute name="transcript_is_canonical"/><Attribute name="external_gene_name"/><Attribute name="external_gene_source"/><Attribute name="hgnc_id"/><Attribute name="uniprot_gn_id"/><Attribute name="uniprotswissprot"/><Attribute name="external_synonym"/></Dataset></Query>'
+#     attempts = 0
+
+#     while not os.path.exists(path_to_file):
+#         download_single_file(url, path_to_file, threads=cores)
+#         attempts += 1
+#         if attempts >= max_attempts:
+#             raise RuntimeError(f"Failed to download MANE summary file after {max_attempts} attempts. Exiting..")
+#         time.sleep(5)
 
 
 def download_biomart_metadata(path_to_file):
@@ -607,10 +634,6 @@ def download_biomart_metadata(path_to_file):
     Query biomart to get the list of transcript corresponding to the downloaded
     structures (a few structures are missing) and other information.
     """
-
-    # command = f"""
-    # wget -O {path_to_file} 'http://jan2024.archive.ensembl.org/biomart/martservice?query=<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE Query><Query virtualSchemaName="default" formatter="TSV" header="0" uniqueRows="0" count="" datasetConfigVersion="0.6"><Dataset name="hsapiens_gene_ensembl" interface="default"><Attribute name="ensembl_gene_id"/><Attribute name="ensembl_transcript_id"/><Attribute name="transcript_is_canonical"/><Attribute name="external_gene_name"/><Attribute name="external_gene_source"/><Attribute name="hgnc_id"/><Attribute name="uniprot_gn_id"/><Attribute name="uniprotswissprot"/></Dataset></Query>'
-    # """
 
     command = f"""
     wget -O {path_to_file} 'http://jan2024.archive.ensembl.org/biomart/martservice?query=<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE Query><Query virtualSchemaName="default" formatter="TSV" header="0" uniqueRows="0" count="" datasetConfigVersion="0.6"><Dataset name="hsapiens_gene_ensembl" interface="default"><Attribute name="ensembl_gene_id"/><Attribute name="ensembl_transcript_id"/><Attribute name="transcript_is_canonical"/><Attribute name="external_gene_name"/><Attribute name="external_gene_source"/><Attribute name="hgnc_id"/><Attribute name="uniprot_gn_id"/><Attribute name="uniprotswissprot"/><Attribute name="external_synonym"/></Dataset></Query>'
@@ -625,29 +648,40 @@ def get_biomart_metadata(datasets_dir, uniprot_ids):
     HGNC IDs, Uniprot IDs, and other useful information.
     """
 
-    download_biomart_metadata(os.path.join(datasets_dir, "biomart_metadata.tsv"))
+    try:
+        path_biomart_metadata = os.path.join(datasets_dir, "biomart_metadata.tsv")
+        if not os.path.exists(path_biomart_metadata):
+            download_biomart_metadata(path_biomart_metadata)
 
-    # Parse
-    biomart_df = pd.read_csv(os.path.join(datasets_dir, "biomart_metadata.tsv"), sep="\t", header=None)
-    biomart_df.columns= ["Ens_Gene_ID", "Ens_Transcr_ID", "Ens_Canonical", "Gene", "Gene_source", "HGNC_ID", "Uniprot_ID", "UniprotKB_ID", "Gene_synonym"]
-    biomart_df = biomart_df.dropna(subset=["Uniprot_ID", "UniprotKB_ID"], how='all')
-    biomart_df = biomart_df[biomart_df["Gene_source"] == "HGNC Symbol"].drop(columns=["Gene_source"])
-    biomart_df.reset_index(inplace=True, drop=True)
+        # Parse
+        biomart_df = pd.read_csv(path_biomart_metadata, sep="\t", header=None, low_memory=False)
+        biomart_df.columns = ["Ens_Gene_ID", "Ens_Transcr_ID", "Ens_Canonical", "Gene", "Gene_source", "HGNC_ID", "Uniprot_ID", "UniprotKB_ID", "Gene_synonym"]
+        biomart_df = biomart_df.dropna(subset=["Uniprot_ID", "UniprotKB_ID"], how='all')
+        biomart_df = biomart_df[biomart_df["Gene_source"] == "HGNC Symbol"].drop(columns=["Gene_source"])
+        biomart_df.reset_index(inplace=True, drop=True)
 
-    # Filter
-    uniprot_ids = pd.Series(uniprot_ids)
-    uniprot_kb_ids = uniprot_ids[(uniprot_ids.isin(biomart_df.UniprotKB_ID))]
-    uniprot_notkb_ids = uniprot_ids[~(uniprot_ids.isin(biomart_df.UniprotKB_ID)) & (uniprot_ids.isin(biomart_df.Uniprot_ID))]
-    biomart_uniprotkb = biomart_df[biomart_df.UniprotKB_ID.isin(uniprot_kb_ids)].drop(
-        columns=["Uniprot_ID"]).rename(columns={"UniprotKB_ID" : "Uniprot_ID"}).drop_duplicates()
-    biomart_uniprot = biomart_df[biomart_df.Uniprot_ID.isin(uniprot_notkb_ids)].drop(columns=["UniprotKB_ID"]).drop_duplicates()
-    biomart_df = pd.concat((biomart_uniprotkb, biomart_uniprot)).reset_index(drop=True)
+        # Filter
+        uniprot_ids = pd.Series(uniprot_ids)
+        uniprot_kb_ids = uniprot_ids[(uniprot_ids.isin(biomart_df.UniprotKB_ID))]
+        uniprot_notkb_ids = uniprot_ids[~(uniprot_ids.isin(biomart_df.UniprotKB_ID)) & (uniprot_ids.isin(biomart_df.Uniprot_ID))]
+        biomart_uniprotkb = biomart_df[biomart_df.UniprotKB_ID.isin(uniprot_kb_ids)].drop(
+            columns=["Uniprot_ID"]).rename(columns={"UniprotKB_ID" : "Uniprot_ID"}).drop_duplicates()
+        biomart_uniprot = biomart_df[biomart_df.Uniprot_ID.isin(uniprot_notkb_ids)].drop(columns=["UniprotKB_ID"]).drop_duplicates()
+        biomart_df = pd.concat((biomart_uniprotkb, biomart_uniprot)).reset_index(drop=True)
 
-    # Output
-    biomart_df.to_csv(os.path.join(datasets_dir, "biomart_metadata.tsv"), sep="\t", index=False)
-    ens_canonical_transcripts = biomart_df.Ens_Transcr_ID[biomart_df["Ens_Canonical"] == 1].unique()
+        # Output
+        biomart_df.to_csv(path_biomart_metadata, sep="\t", index=False)
+        canonical_transcripts = biomart_df.Ens_Transcr_ID[biomart_df["Ens_Canonical"] == 1].unique()
 
-    return ens_canonical_transcripts
+    except Exception as e:
+        logger.warning(
+            "Metadata from BioMart could not be downloaded; transcript IDs will not be prioritized by canonical.  Error was: %s",
+            e,
+            exc_info=True
+        )
+        canonical_transcripts = []
+
+    return canonical_transcripts
 
 
 def get_ref_dna_from_ensembl(transcript_id):
@@ -740,6 +774,45 @@ def drop_gene_duplicates(df):
     return df
 
 
+# def mane_ensprot_to_hugo(
+#     ens_prot_ids,
+#     datasets_dir,
+#     prot_col='Ensembl_prot',
+#     hugo_col='symbol',
+#     strip_version=True
+#     ):
+#     """
+#     Generate a mapping from Ensembl protein IDs to gene symbols.
+#     """
+    
+#     # Load MANE summary
+#     path_mane_summary = os.path.join(datasets_dir, "mane_summary.txt.gz")
+#     if not os.path.exists(path_mane_summary):
+#         download_mane_summary(path_mane_summary, mane_version)
+#     mane_summary = pd.read_csv(path_mane_summary, compression='gzip', sep="\t").dropna(
+#         subset=["symbol", prot_col]
+#         )
+    
+#     # Remove suffix
+#     if strip_version:
+#         mane_summary[prot_col] = mane_summary[prot_col].str.replace(r'\.\d+$', '', regex=True)
+
+#     # Filter and select only the two columns we need
+#     sel = mane_summary.loc[mane_summary[prot_col].isin(ens_prot_ids),[prot_col, hugo_col]]
+
+#     return dict(zip(sel[prot_col], sel[hugo_col]))
+
+
+def mane_uniprot_to_hugo(uniprot_ids, mane_mapping):
+    """
+    Generate a mapping from Uniprot IDs to Hugo Symbols for MANE 
+    transcripts associated structures.
+    """
+    
+    sel = mane_mapping.loc[mane_mapping["Uniprot_ID"].isin(uniprot_ids),["Uniprot_ID", "Gene"]]
+    return dict(zip(sel["Uniprot_ID"], sel["Gene"]))
+
+
 def process_seq_df(seq_df,
                    datasets_dir,
                    organism,
@@ -808,6 +881,8 @@ def process_seq_df(seq_df,
 def process_seq_df_mane(seq_df,
                         datasets_dir,
                         uniprot_to_gene_dict,
+                        mane_mapping,
+                        mane_mapping_not_af,
                         ens_canonical_transcripts_lst,
                         custom_mane_metadata_path=None,
                         num_cores=1,
@@ -823,13 +898,6 @@ def process_seq_df_mane(seq_df,
         -1 : Not available transcripts, seq DNA retrieved from Backtranseq API
     """
 
-    mane_mapping, mane_mapping_not_af = get_mane_to_af_mapping(
-        datasets_dir,
-        seq_df["Uniprot_ID"].unique(),
-        include_not_af=True,
-        mane_version=mane_version,
-        custom_mane_metadata_path=custom_mane_metadata_path
-        )
     seq_df_mane = seq_df[seq_df.Uniprot_ID.isin(mane_mapping.Uniprot_ID)].reset_index(drop=True)
     seq_df_nomane = seq_df[~seq_df.Uniprot_ID.isin(mane_mapping.Uniprot_ID)].reset_index(drop=True)
 
@@ -848,8 +916,13 @@ def process_seq_df_mane(seq_df,
         seq_df_mane_failed = seq_df_mane[failed_ix]
         seq_df_mane = seq_df_mane[~failed_ix]
         seq_df_mane_failed = seq_df_mane_failed.drop(columns=[
-            "Ens_Gene_ID", "Ens_Transcr_ID", "Reverse_strand",
-            "Chr", "Refseq_prot", "Reference_info", "Seq_dna"
+            "Ens_Gene_ID",  
+            "Ens_Transcr_ID", 
+            "Reverse_strand",
+            "Chr", 
+            "Refseq_prot", 
+            "Reference_info", 
+            "Seq_dna"
             ])
         seq_df_nomane = pd.concat((seq_df_nomane, seq_df_mane_failed))
 
@@ -917,7 +990,28 @@ def get_seq_df(datasets_dir,
     uniprot_ids = os.listdir(pdb_dir)
     uniprot_ids = [uni_id.split("-")[1] for uni_id in list(set(uniprot_ids)) if ".pdb" in uni_id]
     logger.debug("Retrieving Uniprot ID to HUGO symbol mapping information..")
-    uniprot_to_gene_dict = uniprot_to_hugo(uniprot_ids)
+    
+    if mane:
+        mane_mapping, mane_mapping_not_af = get_mane_to_af_mapping(
+            datasets_dir,
+            uniprot_ids,
+            include_not_af=True,
+            mane_version=mane_version,
+            custom_mane_metadata_path=custom_mane_metadata_path,
+            cores=num_cores
+            )
+        
+        uniprot_to_gene_dict = dict(zip(mane_mapping["Uniprot_ID"], mane_mapping["Gene"]))
+        missing_uni_ids = list(set(uniprot_ids) - set(mane_mapping.Uniprot_ID))
+        uniprot_to_gene_dict = uniprot_to_gene_dict | uniprot_to_hugo(missing_uni_ids)
+    else:
+        uniprot_to_gene_dict = uniprot_to_hugo(uniprot_ids)
+    
+    # # Check for Ensembl Protein IDs (custom predicted structures)
+    # ens_prot_ids = [uni_id for uni_id in uniprot_ids if uni_id.startswith("ENSP")]
+    # if ens_prot_ids:
+    #     ensprot_to_gene_dict = mane_ensprot_to_hugo(ens_prot_ids, datasets_dir)
+    #     uniprot_to_gene_dict = uniprot_to_gene_dict | ensprot_to_gene_dict
     
     # ---
     # # Workaround if the direct request to UniprotKB stops working (it has happened temporarily)
@@ -938,6 +1032,8 @@ def get_seq_df(datasets_dir,
         seq_df = process_seq_df_mane(seq_df,
                                     datasets_dir,
                                     uniprot_to_gene_dict,
+                                    mane_mapping, 
+                                    mane_mapping_not_af,
                                     ens_canonical_transcripts_lst,
                                     custom_mane_metadata_path,
                                     num_cores,
@@ -966,10 +1062,13 @@ def get_seq_df(datasets_dir,
 
 
 if __name__ == "__main__":
-    DATASETS_DIR = 'oncodrive3d_pipeline/datasets_mane_260723_mane_missing'
-    get_seq_df(datasets_dir=DATASETS_DIR,
-                output_seq_df=os.path.join(DATASETS_DIR, "seq_for_mut_prob.tsv"),
-                organism="Homo sapiens",
-                mane=True,
-                num_cores=8,
-                mane_version=1.4)
+    output_datasets = '/data/bbg/nobackup/scratch/oncodrive3d/tests/datasets_mane_240725_mane_missing_dev'
+    get_seq_df(
+    datasets_dir=output_datasets,
+    output_seq_df=os.path.join(output_datasets, "seq_for_mut_prob.tsv"),
+    organism='Homo sapiens',
+    mane=True,
+    num_cores=8,
+    mane_version=1.4,
+    custom_mane_metadata_path="/data/bbg/nobackup/scratch/oncodrive3d/mane_missing/data/250724-no_fragments/af_predictions/previously_pred/samplesheet.csv"
+    )

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -76,7 +76,9 @@ def build_datasets(output_dir,
     from scripts.datasets.build_datasets import build
     
     startup_message(__version__, "Initializing building datasets..")
-
+    if mane_only:
+        mane = True
+    
     logger.info(f"Current working directory: {os.getcwd()}")
     logger.info(f"Build folder path: {output_dir}")
     logger.info(f"Organism: {organism}")

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -42,11 +42,11 @@ def oncodrive3D():
               help="Use structures predicted from MANE Select transcripts (Homo sapiens only)", is_flag=True)
 @click.option("-M", "--mane_only", 
               help="Use only structures predicted from MANE Select transcripts", is_flag=True)
-@click.option("-C", "--custom_pdb_dir", 
-              help="Directory where to load custom PDB structures (overwriting existing ones)")
-@click.option("-f", "--custom_fasta_dir", 
-              help="Directory where to extract sequence info from FASTA and add it as SEQRES to the custom PDB structures")
-@click.option("-j", "--mane_version", default=1.3, 
+@click.option("-C", "--custom_mane_pdb_dir", 
+              help="Directory where to load custom MANE PDB structures (overwriting existing ones)")
+@click.option("-f", "--custom_mane_metadata_path", 
+              help="Path to a dataframe including the Ensembl Protein ID and the amino acid sequence of the custom MANE PDB structures")
+@click.option("-j", "--mane_version", default=1.4, 
               help="Version of the MANE Select release from NCBI")
 @click.option("-d", "--distance_threshold", type=click.INT, default=10,
               help="Distance threshold (Å) to define contact between amino acids")
@@ -63,8 +63,8 @@ def build_datasets(output_dir,
                    organism,
                    mane,
                    mane_only,
-                   custom_pdb_dir,
-                   custom_fasta_dir,
+                   custom_mane_pdb_dir,
+                   custom_mane_metadata_path,
                    distance_threshold,
                    cores, 
                    af_version,
@@ -82,8 +82,8 @@ def build_datasets(output_dir,
     logger.info(f"Organism: {organism}")
     logger.info(f"MANE Select: {mane}")
     logger.info(f"MANE Select only: {mane_only}")
-    logger.info(f"Custom PDB directory: {custom_pdb_dir}")
-    logger.info(f"Custom FASTA directory: {custom_fasta_dir}")
+    logger.info(f"Custom MANE PDB directory: {custom_mane_pdb_dir}")
+    logger.info(f"Custom MANE PDB metadata path: {custom_mane_metadata_path}")
     logger.info(f"Distance threshold: {distance_threshold}Å")
     logger.info(f"CPU cores: {cores}")
     logger.info(f"AlphaFold version: {af_version}")
@@ -92,16 +92,18 @@ def build_datasets(output_dir,
     logger.info(f'Log path: {os.path.join(output_dir, "log")}')
     logger.info("")
     
-    build(output_dir,
-          organism,
-          mane,
-          mane_only,
-          custom_pdb_dir,
-          custom_fasta_dir,
-          distance_threshold,
-          cores,
-          af_version,
-          mane_version)
+    build(
+        output_dir,
+        organism,
+        mane,
+        mane_only,
+        custom_mane_pdb_dir,
+        custom_mane_metadata_path,
+        distance_threshold,
+        cores,
+        af_version,
+        mane_version
+        )
 
 
 

--- a/scripts/run/utils.py
+++ b/scripts/run/utils.py
@@ -31,7 +31,6 @@ def get_seq_df_input_symbols(input_df, seq_df, mane=False):
     seq_df_tr_available = seq_df_tr_available.drop(columns=["Gene"]).drop_duplicates().merge(df_mapping, how="left", on="Ens_Transcr_ID")
 
     # If the same gene is associated to multiple structures, keep the first one obtained from Uniprot (descending, Reference_info 1) or keep the MANE (ascending, Reference_info 0)
-    # TO DO: Use the one reviewed (UniProtKB reviewed (Swiss-Prot)), if multiple Uniprot ones are present. The info must be added during the build step
     order_ascending = [True, mane]
     seq_df_tr_available = seq_df_tr_available.sort_values(by=["Gene", "Reference_info"], ascending=order_ascending).drop_duplicates(subset="Gene")
 

--- a/tools/preprocessing/prepare_samplesheet.py
+++ b/tools/preprocessing/prepare_samplesheet.py
@@ -175,7 +175,7 @@ class ManeSamplesheetBuilder:
         # Save
         sheet = self._add_refseq(sheet)
         sheet.to_csv(self.samplesheet_path, index=False)
-        print(f"Wrote samplesheet to {self.samplesheet_path!r}")
+        print(f"Wrote samplesheet to {self.samplesheet_path}")
         
         return sheet
 
@@ -222,13 +222,13 @@ def main(datasets_dir, output_dir, mane_version, no_fragments, cores):
     # Log the parameters
     print("Running with parameters:")
     for name, val in {
-        "datasets_dir": datasets_dir,
-        "output_dir": output_dir,
-        "mane_version": mane_version,
-        "no_fragments": no_fragments,
-        "cores": cores
+        "datasets_dir   ": datasets_dir,
+        "output_dir     ": output_dir,
+        "mane_version   ": mane_version,
+        "no_fragments   ": no_fragments,
+        "cores          ": cores
         }.items():
-        print("  %s = %r", name, val)
+        print(f"{name} = {val}")
 
     builder = ManeSamplesheetBuilder(
         datasets_dir=datasets_dir,
@@ -236,24 +236,17 @@ def main(datasets_dir, output_dir, mane_version, no_fragments, cores):
         mane_version=mane_version,
         no_fragments=no_fragments
     )
-    builder = ManeSamplesheetBuilder(
-        datasets_dir=args.datasets_dir,
-        output_dir=args.output_dir,
-        mane_version=args.mane_version,
-        no_fragments=args.no_fragments,
-        cores=cores
-    )
     builder.build()
     
 
 if __name__ == "__main__":
-    # main()
+    main()
     
-    # For debugging
-    builder = ManeSamplesheetBuilder(
-        datasets_dir="/data/bbg/nobackup/scratch/oncodrive3d/datasets_mane_240506/",
-        output_dir="/data/bbg/nobackup/scratch/oncodrive3d/mane_missing/data/250724-no_fragments",
-        cores=len(os.sched_getaffinity(0)),
-        no_fragments=True
-        )
-    builder.build()
+    # # For debugging
+    # builder = ManeSamplesheetBuilder(
+    #     datasets_dir="/data/bbg/nobackup/scratch/oncodrive3d/datasets_mane_240506/",
+    #     output_dir="/data/bbg/nobackup/scratch/oncodrive3d/mane_missing/data/250728-all_proteins",
+    #     cores=len(os.sched_getaffinity(0)),
+    #     no_fragments=True
+    #     )
+    # builder.build()

--- a/tools/preprocessing/prepare_samplesheet.py
+++ b/tools/preprocessing/prepare_samplesheet.py
@@ -1,0 +1,259 @@
+"""
+prepare_samplesheet.py
+
+Utility to download the MANE Ensembl protein FASTA, filter out entries
+already in AlphaFold, write individual .fasta files, and assemble a
+samplesheet.csv for downstream nf-core AlphaFold pipeline.
+
+Example usage:
+    python -m tools.preprocessing.prepare_samplesheet \
+        --datasets-dir  /data/bbg/nobackup/scratch/oncodrive3d/datasets_mane_240506/ \
+        --output-dir    /data/bbg/nobackup/scratch/oncodrive3d/mane_missing/data
+"""
+
+
+import os
+import click
+import gzip
+import time
+import pandas as pd
+from pathlib import Path
+from scripts.datasets.utils import download_single_file
+# import logging
+
+# logger = logging.getLogger(__name__)
+
+class ManeSamplesheetBuilder:
+    """
+    Download MANE FASTA, merge with AlphaFold mapping, 
+    write out individual FASTAs, and assemble the final samplesheet.
+    """
+
+    def __init__(
+        self,
+        datasets_dir: str,
+        output_dir: str,
+        mane_version: str = "1.4",
+        max_attempts: int = 15,
+        no_fragments: bool = True,
+        cores: int = 1,
+    ):
+        self.datasets_dir = Path(datasets_dir)
+        self.output_dir = Path(output_dir)
+        self.mane_version = mane_version
+        self.max_attempts = max_attempts
+        self.no_fragments = no_fragments
+        self.cores = cores
+        
+        self.fasta_gz = self.output_dir / f"MANE.GRCh38.v{mane_version}.ensembl_protein.faa.gz"
+        self.fasta_dir = self.output_dir / "fasta"
+        self.samplesheet_path = self.output_dir / "samplesheet.csv"
+
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+
+
+    def _download_mane_fasta(self):
+        """Download the MANE Ensembl protein FASTA (gzipped)."""
+        url = (
+            f"https://ftp.ncbi.nlm.nih.gov/refseq/MANE/MANE_human"
+            f"/release_{self.mane_version}/MANE.GRCh38.v{self.mane_version}.ensembl_protein.faa.gz"
+        )
+        attempts = 0
+        while attempts < self.max_attempts:
+            try:
+                download_single_file(url, str(self.fasta_gz), threads=self.cores)
+                print("Downloaded MANE FASTA successfully.")
+                return
+            except Exception as e:
+                attempts += 1
+                print(f"Attempt {attempts} failed: {e!r}")
+                time.sleep(5)
+        raise RuntimeError(f"Failed to download MANE FASTA after {self.max_attempts} attempts.")
+
+
+    def _parse_ncbi_mane_fasta(self) -> pd.DataFrame:
+        """
+        Parse the gzipped FASTA into a DataFrame with columns
+        ['sequence', 'refseq'] where 'sequence' is the Ensembl ID
+        (no version) and 'refseq' is the AA string.
+        """
+        if not self.fasta_gz.exists():
+            raise FileNotFoundError(self.fasta_gz)
+        ids, seqs = [], []
+        with gzip.open(self.fasta_gz, "rt") as fh:
+            header = None
+            seq_parts = []
+            for line in fh:
+                line = line.rstrip()
+                if line.startswith(">"):
+                    if header is not None:
+                        ids.append(header)
+                        seqs.append("".join(seq_parts))
+                    raw = line[1:].split()[0]
+                    header = raw.split(".", 1)[0]
+                    seq_parts = []
+                else:
+                    seq_parts.append(line)
+            # last record
+            if header is not None:
+                ids.append(header)
+                seqs.append("".join(seq_parts))
+
+        return pd.DataFrame({"sequence": ids, "refseq": seqs})
+
+
+    def _load_mane_af(self) -> pd.DataFrame:
+        """
+        Load the mapping of RefSeq-UniProt-Ensembl_prot
+        and return a DataFrame with 'refseq_prot' and
+        version‐stripped 'Ensembl_prot'.
+        """
+        map_csv = self.datasets_dir / "mane_refseq_prot_to_alphafold.csv"
+        sum_gz   = self.datasets_dir / "mane_summary.txt.gz"
+
+        df_map = pd.read_csv(map_csv)
+        self.df_mane_summary = (
+            pd.read_csv(sum_gz, compression="gzip", sep="\t")
+            .rename(columns={"RefSeq_prot": "refseq_prot"})
+            .dropna(subset=["Ensembl_prot", "refseq_prot"])
+            )
+        df = df_map.merge(self.df_mane_summary[["refseq_prot", "Ensembl_prot"]], on="refseq_prot", how="inner")
+        df["Ensembl_prot"] = df["Ensembl_prot"].str.split(".", n=1).str[0]
+        
+        return df
+
+
+    def _add_refseq(self, df):
+        """Add RefSeq Protein information to the samplesheet"""
+        mane_summary = self.df_mane_summary.rename(
+            columns={"Ensembl_prot": "sequence"}
+            )[["sequence", "refseq_prot"]]
+        mane_summary["sequence"] = mane_summary["sequence"].str.split(".", n=1).str[0]
+        df = df.merge(mane_summary, on="sequence", how="left")
+        
+        return df
+
+
+    def write_fastas_and_update_sheet(self, df: pd.DataFrame) -> pd.DataFrame:
+        """
+        For every row in df, write a .fasta file under self.fasta_dir,
+        then insert 'fasta' and 'length' columns and return samplesheet df.
+        """
+
+        df = df.copy()
+        df["length"] = df["refseq"].str.len()
+        self.fasta_dir.mkdir(exist_ok=True, parents=True)
+
+        if self.no_fragments:
+            df = df[df["length"] < 2400].reset_index(drop=True)
+
+        # Build fasta paths and write files
+        fasta_paths = []
+        for seq_id, seq, length in zip(df["sequence"], df["refseq"], df["length"]):
+            p = self.fasta_dir / f"{seq_id}.fasta"
+            fasta_str = f">{seq_id} | {length} aa\n{seq}\n"
+            p.write_text(fasta_str)
+            fasta_paths.append(str(p))
+
+        df.insert(1, "fasta", fasta_paths)
+
+        return df
+
+
+    def build(self) -> pd.DataFrame:
+        """
+        Run the full workflow and write out fastas and samplesheet.csv.
+        """
+        self._download_mane_fasta()
+        mane_all = self._parse_ncbi_mane_fasta()
+        mane_af = self._load_mane_af()
+
+        # Keep only those not already in AF
+        mane_missing_af = mane_all[~mane_all["sequence"].isin(mane_af["Ensembl_prot"])]
+        sheet = self.write_fastas_and_update_sheet(mane_missing_af)
+        
+        # Save
+        sheet = self._add_refseq(sheet)
+        sheet.to_csv(self.samplesheet_path, index=False)
+        print(f"Wrote samplesheet to {self.samplesheet_path!r}")
+        
+        return sheet
+
+
+@click.command(context_settings={"help_option_names": ["-h", "--help"]})
+@click.option(
+    "--datasets-dir", "-d",
+    required=True,         # This could be optional if we download mane_refseq_prot_to_alphafold.csv from AlphaFold DB and mane_summary.txt.gz from ncbi
+    type=click.Path(exists=True, file_okay=False, dir_okay=True),
+    help="Path to Oncodrive3D datasets or folder containing AF‑MANE mapping (mane_refseq_prot_to_alphafold.csv) and summary (mane_summary.txt.gz) files"
+)
+@click.option(
+    "--output-dir", "-o",
+    required=True,
+    type=click.Path(file_okay=False, dir_okay=True),
+    help="Where to write the downloaded FASTA, individual .fasta files, and samplesheet"
+)
+@click.option(
+    "--mane-version", "-v",
+    default="1.4",
+    show_default=True,
+    help="MANE release version to download (e.g. 1.4)"
+)
+@click.option(
+    "--no-fragments",
+    is_flag=True,
+    default=False,
+    help="Drop any sequences ≥2400 aa from the samplesheet"
+)
+@click.option(
+    "-c", "--cores",
+    type=click.IntRange(min=1, max=len(os.sched_getaffinity(0))),
+    default=len(os.sched_getaffinity(0)),
+    show_default=True,
+    help="Number of cores to use in the computation"
+)
+def main(datasets_dir, output_dir, mane_version, no_fragments, cores):
+    """
+    Build a nf‑core AlphaFold samplesheet by downloading MANE FASTA,
+    filtering out existing AF entries, writing per‑protein FASTAs,
+    and emitting a samplesheet.csv.
+    """
+    
+    # Log the parameters
+    print("Running with parameters:")
+    for name, val in {
+        "datasets_dir": datasets_dir,
+        "output_dir": output_dir,
+        "mane_version": mane_version,
+        "no_fragments": no_fragments,
+        "cores": cores
+        }.items():
+        print("  %s = %r", name, val)
+
+    builder = ManeSamplesheetBuilder(
+        datasets_dir=datasets_dir,
+        output_dir=output_dir,
+        mane_version=mane_version,
+        no_fragments=no_fragments
+    )
+    builder = ManeSamplesheetBuilder(
+        datasets_dir=args.datasets_dir,
+        output_dir=args.output_dir,
+        mane_version=args.mane_version,
+        no_fragments=args.no_fragments,
+        cores=cores
+    )
+    builder.build()
+    
+
+if __name__ == "__main__":
+    # main()
+    
+    # For debugging
+    builder = ManeSamplesheetBuilder(
+        datasets_dir="/data/bbg/nobackup/scratch/oncodrive3d/datasets_mane_240506/",
+        output_dir="/data/bbg/nobackup/scratch/oncodrive3d/mane_missing/data/250724-no_fragments",
+        cores=len(os.sched_getaffinity(0)),
+        no_fragments=True
+        )
+    builder.build()


### PR DESCRIPTION
## Summary

This PR updates our `build-datasets` pipeline in Oncodrive3D so that it pulls MANE Select data directly from NCBI instead of querying UniProt. It also introduces a standalone preprocessing utility that begins by downloading the full MANE release from NCBI, bypassing UniProt entirely, and then generates per‑protein FASTA files along with a `samplesheet.csv` for any MANE‑associated structures missing from the AlphaFold database. These outputs can be fed directly into the nf‑core AlphaFold 2 pipeline to predict the missing structures.

This PR close the issue #61

## Key Changes

### 1. `build-datasets` refactoring

- **Switch data source**  
  Replace UniProt API lookups with download & parsing of MANE files from NCBI for MANE-transcripts associated structures. 
 
- **Transcript mapping**  
  Leverage NCBI MANE metadata to populate transcript IDs for every MANE Select entry—virtually eliminating missing transcript annotations for MANE-transcripts associated structures.

- **Metadata update**  
In-house predicted PDB structures can be integrated with those downloaded from the AlphaFold database by specifying:
    * `--custom_mane_pdb_dir`: the path to the directory containing the custom PDB files.
    * `--custom_mane_metadata`: the path to a metadata dataframe (CSV or TSV) describing these structures.  

  The metadata dataframe must contain two columns:
    * `sequence`: the Ensembl protein ID used as the identifier for each structure.
    * `refseq`: the corresponding amino acid sequence for each protein.

  When these arguments are provided, the build-datasets step processes the in-house predicted structures by replacing the UniProt IDs in the `seq_for_mut_prob.tsv` file with the corresponding Ensembl protein IDs. This ensures that any structures generated using the new samplesheet, which may lack UniProt mappings, are consistently referenced by their Ensembl IDs throughout Oncodrive3D. If the amino acid sequence is missing from the in-house PDB files, it will attempt to retrieve the sequence from the file provided via `--custom_mane_metadata` and write it directly into the corresponding PDB file.

- **Backward compatibility**  
    Default workflow remain unchanged unless `--mane`, `--mane_only` flags are explicitly used or  `--custom_mane_pdb_dir` and `custom_mane_metadata_path` are provided.

### 2. New preprocessing tool: `prepare_samplesheet.py`

- **Purpose**  
  Identify MANE proteins (from a specific version) not yet present in the AlphaFold DB, then build:
  - A `samplesheet.csv` listing each Ensembl protein ID, its RefSeq sequence (not necessary), and local FASTA path.
  - Individual FASTA files (`<EnsemblID>.fasta`) for downstream AlphaFold nf‑core runs.
  
- **Advantages**  
  - Fully independent of UniProt and AlphaFold 2 Database MANE download, which is still at version 1.0.
  - Captures sequences even when no UniProt mapping exists.
  - Ready to feed directly into AlphaFold 2 for “missing” structure predictions.

## Tests

- [x] Test `build-datasets using` `--mane_only` and providing custom PDBs
- [x] Test run using above build and compare result to previous run
- [x] Test `build-datasets using` using `--mane`
- [x] Test run using above build and compare result to previous run
- [x] Test `build-datasets using default args
- [x] Test run using above build and compare result to previous run

## Still missing
- [x] Doc

