### PR TITLE
Increase protein length threshold for unfragmented samplesheet preprocessing

### DIFF
--- a/scripts/datasets/build_datasets.py
+++ b/scripts/datasets/build_datasets.py
@@ -160,12 +160,12 @@ def build(output_datasets,
 
 if __name__ == "__main__":
     build(
-      output_datasets="/data/bbg/nobackup/scratch/oncodrive3d/tests/datasets_mane_250725_mane_missing_dev",
+      output_datasets="/data/bbg/nobackup/scratch/oncodrive3d/mane_missing/oncodrive3d/datasets/datasets-mane_only-mane_custom-250729",
       organism="Homo sapiens",
       mane=False,
       mane_only=True,
-      custom_pdb_dir="/data/bbg/nobackup/scratch/oncodrive3d/mane_missing/data/250724-no_fragments/af_predictions/previously_pred",
-      custom_mane_metadata_path="/data/bbg/nobackup/scratch/oncodrive3d/mane_missing/data/250724-no_fragments/af_predictions/previously_pred/samplesheet.csv",
+      custom_pdb_dir="/data/bbg/nobackup/scratch/oncodrive3d/mane_missing/data/250724-no_fragments/all_pdbs-pred_and_retrieved/pdbs",
+      custom_mane_metadata_path="/data/bbg/nobackup/scratch/oncodrive3d/mane_missing/data/250724-no_fragments/all_pdbs-pred_and_retrieved/samplesheet.csv",
       distance_threshold=10,
       num_cores=8,
       af_version=4,

--- a/tools/preprocessing/prepare_samplesheet.py
+++ b/tools/preprocessing/prepare_samplesheet.py
@@ -145,7 +145,7 @@ class ManeSamplesheetBuilder:
         self.fasta_dir.mkdir(exist_ok=True, parents=True)
 
         if self.no_fragments:
-            df = df[df["length"] < 2400].reset_index(drop=True)
+            df = df[df["length"] <= 2700].reset_index(drop=True)
 
         # Build fasta paths and write files
         fasta_paths = []


### PR DESCRIPTION
This pull request updates the preprocessing tool to generate the samplesheet and FASTA files for predicting structures missing in the MANE Select download.

**Key Change**

- The length threshold for including proteins in the samplesheet has been updated from < 2400 to ≤ 2700 amino acids.
- This change aligns with AlphaFold2 recommendations and matches the threshold used in AlphaFold2’s default usage.
- This change enables the prediction of a few additional structures that were previously considered too long and therefore split into fragments.