### PR TITLE
Fix build-datasets AlphaFold download after symlink change

### DIFF
--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,2 +1,2 @@
 __logger_name__ = 'oncodrive3d'
-__version__ = "1.0.6"
+__version__ = "1.0.7"

--- a/scripts/datasets/get_structures.py
+++ b/scripts/datasets/get_structures.py
@@ -67,7 +67,7 @@ def get_structures(path: str,
     if mane:
         if species == "Homo sapiens":
             if str(af_version) not in {"3", "4"}:
-                raise RuntimeError("AlphaFold MANE overlaps are available only for versions 3 or 4. Please set --af_version to 3 or 4 when using --mane/--mane_only.")
+                raise RuntimeError("AlphaFold MANE overlaps are available only for versions 3 or 4. When using --mane or --mane_only, please set --af_version to 3 or 4.")
             proteome = f"mane_overlap_v{af_version}"
         else:
             raise RuntimeError("Structures with MANE transcripts overlap are available only for 'Homo sapiens'. Exiting...")

--- a/scripts/datasets/get_structures.py
+++ b/scripts/datasets/get_structures.py
@@ -66,6 +66,8 @@ def get_structures(path: str,
     # Select proteome
     if mane:
         if species == "Homo sapiens":
+            if str(af_version) not in {"3", "4"}:
+                raise RuntimeError("AlphaFold MANE overlaps are available only for versions 3 or 4. Please set --af_version to 3 or 4 when using --mane/--mane_only.")
             proteome = f"mane_overlap_v{af_version}"
         else:
             raise RuntimeError("Structures with MANE transcripts overlap are available only for 'Homo sapiens'. Exiting...")
@@ -78,7 +80,7 @@ def get_structures(path: str,
             raise RuntimeError(f"Failed to recognize '{species}' as organism. Currently accepted ones are 'Homo sapiens' and 'Mus musculus'. Exiting...")
 
     logger.debug(f"Proteome to download: {proteome}")
-    af_url = f"https://ftp.ebi.ac.uk/pub/databases/alphafold/latest/{proteome}.tar"
+    af_url = f"https://ftp.ebi.ac.uk/pub/databases/alphafold/v{af_version}/{proteome}.tar"
     file_path = os.path.join(path, f"{proteome}.tar")
 
     try:

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -52,7 +52,7 @@ def oncodrive3D():
               help="Distance threshold (Å) to define contact between amino acids")
 @click.option("-c", "--cores", type=click.IntRange(min=1, max=len(os.sched_getaffinity(0)), clamp=False), default=len(os.sched_getaffinity(0)),
               help="Number of cores to use in the computation")
-@click.option("--af_version", type=click.IntRange(min=1, max=4, clamp=False), default=4,
+@click.option("--af_version", type=click.IntRange(min=1, clamp=False), default=4,
               help="Version of AlphaFold 2 predictions")
 @click.option("-y", "--yes", 
               help="No interaction", is_flag=True)
@@ -498,6 +498,8 @@ def plot(gene_result_path,
 @click.option("--fragmented_proteins", help="Include fragmented proteins", is_flag=True)
 @click.option("--transparent_bg", help="Set background as transparent", type=str, is_flag=True)
 @click.option("--chimerax_bin", help="Path to chimerax installation", type=str, default="/usr/bin/chimerax")
+@click.option("--af_version", type=click.IntRange(min=1, clamp=False), default=4,
+              help="Version of AlphaFold 2 predictions used for structures")
 @click.option("-v", "--verbose", help="Verbose", is_flag=True)
 @setup_logging_decorator
 def chimerax_plot(output_dir,
@@ -512,6 +514,7 @@ def chimerax_plot(output_dir,
                   fragmented_proteins,
                   transparent_bg,
                   chimerax_bin,
+                  af_version,
                   verbose):
     """"Generate images of structures annotated with clustering metrics."""
 
@@ -529,6 +532,7 @@ def chimerax_plot(output_dir,
     logger.info(f"Cluster extended: {cluster_ext}")
     logger.info(f"Fragmented proteins: {fragmented_proteins}")
     logger.info(f"Transparent background: {transparent_bg}")
+    logger.info(f"AlphaFold version: {af_version}")
     logger.info(f"Verbose: {bool(verbose)}")
     logger.info(f'Log path: {os.path.join(output_dir, "log")}')
     logger.info("")
@@ -544,7 +548,8 @@ def chimerax_plot(output_dir,
                         cluster_ext,
                         fragmented_proteins,
                         transparent_bg,
-                        chimerax_bin)
+                        chimerax_bin,
+                        af_version)
 
 if __name__ == "__main__":
     oncodrive3D()

--- a/scripts/plotting/chimerax_plot.py
+++ b/scripts/plotting/chimerax_plot.py
@@ -142,7 +142,8 @@ def generate_chimerax_plot(output_dir,
                             cluster_ext,
                             fragmented_proteins,
                             transparent_bg,
-                            chimerax_bin):
+                            chimerax_bin,
+                            af_version):
 
     seq_df = pd.read_csv(seq_df_path, sep="\t")
     gene_result = pd.read_csv(gene_result_path)
@@ -180,7 +181,10 @@ def generate_chimerax_plot(output_dir,
                              "Logscore_obs_sim"]], on="Pos", how="left")
 
             uni_id, f = seq_df[seq_df["Gene"] == gene][["Uniprot_ID", "F"]].values[0]
-            pdb_path = os.path.join(datasets_dir, "pdb_structures", f"AF-{uni_id}-F{f}-model_v4.pdb")
+            pdb_path = os.path.join(datasets_dir, "pdb_structures", f"AF-{uni_id}-F{f}-model_v{af_version}.pdb")
+            if not os.path.exists(pdb_path):
+                pdb_gz_path = f"{pdb_path}.gz"
+                pdb_path = pdb_gz_path if os.path.exists(pdb_gz_path) else pdb_path
             
             labels = {"mutres" : "Mutations in residue ", 
                       "mutvol" : "Mutations in volume ",

--- a/scripts/plotting/chimerax_plot.py
+++ b/scripts/plotting/chimerax_plot.py
@@ -181,10 +181,9 @@ def generate_chimerax_plot(output_dir,
                              "Logscore_obs_sim"]], on="Pos", how="left")
 
             uni_id, f = seq_df[seq_df["Gene"] == gene][["Uniprot_ID", "F"]].values[0]
-            pdb_path = os.path.join(datasets_dir, "pdb_structures", f"AF-{uni_id}-F{f}-model_v{af_version}.pdb")
-            if not os.path.exists(pdb_path):
-                pdb_gz_path = f"{pdb_path}.gz"
-                pdb_path = pdb_gz_path if os.path.exists(pdb_gz_path) else pdb_path
+            pdb_path_base = os.path.join(datasets_dir, "pdb_structures", f"AF-{uni_id}-F{f}-model_v{af_version}.pdb")
+            pdb_candidates = [pdb_path_base, f"{pdb_path_base}.gz"]
+            pdb_path = next((candidate for candidate in pdb_candidates if os.path.exists(candidate)), None)
             
             labels = {"mutres" : "Mutations in residue ", 
                       "mutvol" : "Mutations in volume ",
@@ -200,7 +199,7 @@ def generate_chimerax_plot(output_dir,
                     logger.debug(f"Fragmented protein processing {fragmented_proteins}: Skipping {gene} ({uni_id}-F{f})..")
                     continue
                 
-            if os.path.exists(pdb_path):
+            if pdb_path:
                 
                 for attribute in ["mutres", "mutvol", "score", "logscore"]:
                     
@@ -252,6 +251,6 @@ def generate_chimerax_plot(output_dir,
                         logger.debug(chimerax_command)
                         
             else:
-                logger.warning(f"PDB path missing: {pdb_path}")
+                logger.warning(f"Structure not found for {uni_id}-F{f} (AlphaFold v{af_version}). Tried: {', '.join(pdb_candidates)}")
     else:
         logger.info("Nothing to plot!")

--- a/scripts/plotting/chimerax_plot.py
+++ b/scripts/plotting/chimerax_plot.py
@@ -251,6 +251,7 @@ def generate_chimerax_plot(output_dir,
                         logger.debug(chimerax_command)
                         
             else:
-                logger.warning(f"Structure not found for {uni_id}-F{f} (AlphaFold v{af_version}). Tried: {', '.join(pdb_candidates)}")
+                tried_files = ', '.join(os.path.basename(path) for path in pdb_candidates)
+                logger.warning(f"Structure not found for {uni_id}-F{f} (AlphaFold v{af_version}). Tried: {tried_files}")
     else:
         logger.info("Nothing to plot!")


### PR DESCRIPTION
- Fixed AlphaFold dataset downloads breaking after the upstream “latest” symlink moved by switching our fetcher to versioned URLs and adding an explicit guard when MANE structures are requested (only valid for AF v3/4).
- Updated the ChimeraX plotting command to accept --af_version, use version-aware path resolution, and fall back to gzipped models when needed.
- Relaxed the upper bound on the `--af_version` CLI argument to allow any integer >= 1, instead of restricting to 1-4.