### PR TITLE
Add parser to flatten nested AlphaFold predictions

### DIFF
--- a/tools/preprocessing/README.md
+++ b/tools/preprocessing/README.md
@@ -21,7 +21,7 @@ Download the requested MANE protein FASTA from NCBI and materialize FASTA files 
 ### Usage
 
 ```bash
-uv run python tools.preprocessing.prepare_samplesheet.py \
+uv run python tools/preprocessing/prepare_samplesheet.py \
     --mane-dataset-dir /path/to/o3d_mane_only_dataset \
     --output-dir   /path/to/mane_missing/data
 ```
@@ -74,7 +74,7 @@ Non-runtime paths still live in `config.yaml`:
 ### Usage
 
 ```bash
-uv run python tools.preprocessing.update_samplesheet_and_structures.py \
+uv run python tools/preprocessing/update_samplesheet_and_structures.py \
     --samplesheet-folder /path/to/mane_missing/data \
     --mane-dataset-dir /path/to/mane_only_dataset \
     [--canonical-dir   /path/to/af_canonical_pdbs] \
@@ -86,10 +86,17 @@ Arguments:
 - `--samplesheet-folder` (**required**): Absolute path to the folder created by `prepare_samplesheet.py` (contains `samplesheet.csv` + `fasta/`).
 - `--mane-dataset-dir` (**required**): Path to the MANE-only dataset built via `oncodrive3d build-datasets --mane_only`.
 - `--canonical-dir`: Path to the dataset including UniProt canonical structures built via `oncodrive3d build-datasets` or `oncodrive3d build-datasets --mane`. The directory must contain both `pdb_structures/` and `seq_for_mut_prob.tsv` so the tool can match missing ENSPs to canonical PDBs by amino-acid sequence.
-- `--predicted-dir`: Path to the directory containing nf-core/proteinfold PDBs to ingest; omit it if you only want to reuse AF canonical structures in this pass.
+- `--predicted-dir`: Path to a directory containing predicted PDBs to ingest.
+  - If your prediction run outputs a flat folder of PDBs named like `ENSP0000....pdb`, point `--predicted-dir` to that folder.
+  - If your prediction run outputs nested `ENSP*` folders with a `ranked_0.pdb` inside (no ENSP identifier in the filename), first flatten it with:
+    ```bash
+    uv run python tools/preprocessing/flatten_alphafold_predictions.py \
+        --predicted-dir /path/to/nested/predictions \
+        --output-dir    /path/to/flat/pdbs
+    ```
+    and then pass `--predicted-dir /path/to/flat/pdbs`.
 - `--cgc-list-path`: Path to the Cancer Gene Census TSV (optional; only needed for CGC prioritisation). Download available from the CGC website (registration required).
 - `--max-workers`: Parallel workers for canonical indexing (default = all cores).
-- `--enable-canonical-reuse/--disable-canonical-reuse`: Toggle canonical harvesting (enabled by default when `--canonical-dir` is provided).
 - `--filter-long-sequences/--no-filter-long-sequences`: Whether to drop long proteins from the nf-core input (default enabled).
 - `--max-sequence-length`: Length cutoff applied when filtering (default `2700` residues).
 - `--include-metadata/--no-include-metadata`: Add `symbol`, `CGC`, and `length` columns to every emitted `samplesheet.csv` (default disabled).

--- a/tools/preprocessing/README.md
+++ b/tools/preprocessing/README.md
@@ -48,7 +48,7 @@ Inside the chosen `--output-dir` you will find:
 
 - `MANE.GRCh38.vX.Y.ensembl_protein.faa.gz` – cached MANE FASTA download.
 - `fasta/ENSP....fasta` – one FASTA per missing ENSP (filtered for length if requested).
-- `samplesheet.csv` – columns include `sequence`, `fasta`, `refseq`, `length`, `refseq_prot`, etc.
+- `samplesheet.csv` – columns include `sequence`, `fasta`, `aa_sequence`, `length`, `refseq_prot`, etc.
 
 Feed these files to `update_samplesheet_and_structures.py` and/or directly into nf-core/proteinfold.
 
@@ -90,7 +90,7 @@ Arguments:
   - If your prediction run outputs a flat folder of PDBs named like `ENSP0000....pdb`, point `--predicted-dir` to that folder.
   - If your prediction run outputs nested `ENSP*` folders with a `ranked_0.pdb` inside (no ENSP identifier in the filename), first flatten it with:
     ```bash
-    uv run python tools/preprocessing/flatten_alphafold_predictions.py \
+    uv run python tools/preprocessing/parse_alphafold_predictions.py \
         --predicted-dir /path/to/nested/predictions \
         --output-dir    /path/to/flat/pdbs
     ```

--- a/tools/preprocessing/parse_alphafold_predictions.py
+++ b/tools/preprocessing/parse_alphafold_predictions.py
@@ -2,7 +2,7 @@
 """
 Parse nested AlphaFold predictions into a simple PDB folder.
 
-A recent AlphaFold pipeline produce one directory per protein (ENSP...) 
+A recent AlphaFold pipeline produces one directory per protein (ENSP...) 
 with the actual structure nested inside and named `ranked_0.pdb`.
 
 This script scans a `--predicted-dir` containing multiple `ENSP*` folders,

--- a/tools/preprocessing/parser_alphafold_predictions.py
+++ b/tools/preprocessing/parser_alphafold_predictions.py
@@ -9,7 +9,7 @@ This script scans a `--predicted-dir` containing multiple `ENSP*` folders,
 finds each folder's `ranked_0.pdb` (or `ranked_0.pdb.gz`), and copies it to
 `--output-dir` as:
 
-    <ENSP_ID>.alphafold.pdb
+    <ENSP_ID>.1.alphafold.pdb
 """
 
 from __future__ import annotations
@@ -83,7 +83,7 @@ def cli(predicted_dir: Path, output_dir: Path) -> None:
             missing += 1
             continue
 
-        dst = output_dir / f"{ensp_id}.alphafold.pdb"
+        dst = output_dir / f"{ensp_id}.1.alphafold.pdb"
         try:
             copy_pdb(ranked, dst)
             copied += 1

--- a/tools/preprocessing/parser_alphafold_predictions.py
+++ b/tools/preprocessing/parser_alphafold_predictions.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""
+Parse nested AlphaFold predictions into a simple PDB folder.
+
+A recent AlphaFold pipeline produce one directory per protein (ENSP...) 
+with the actual structure nested inside and named `ranked_0.pdb`.
+
+This script scans a `--predicted-dir` containing multiple `ENSP*` folders,
+finds each folder's `ranked_0.pdb` (or `ranked_0.pdb.gz`), and copies it to
+`--output-dir` as:
+
+    <ENSP_ID>.alphafold.pdb
+"""
+
+from __future__ import annotations
+
+import gzip
+import shutil
+from pathlib import Path
+
+import click
+
+
+def find_ranked_structure(ensp_folder: Path) -> Path | None:
+    """Return the path to ranked_0.pdb (or ranked_0.pdb.gz) under ensp_folder."""
+    candidates = list(ensp_folder.rglob("ranked_0.pdb"))
+    if not candidates:
+        candidates = list(ensp_folder.rglob("ranked_0.pdb.gz"))
+    if not candidates:
+        return None
+
+    ensp_id = ensp_folder.name
+    preferred = [path for path in candidates if path.parent.name == ensp_id]
+    if preferred:
+        candidates = preferred
+
+    candidates.sort(key=lambda path: path.as_posix())
+    return candidates[0]
+
+
+def copy_pdb(src: Path, dst: Path) -> None:
+    """Copy src -> dst, transparently handling gzipped input."""
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    if src.suffix == ".gz":
+        with gzip.open(src, "rb") as handle_src, dst.open("wb") as handle_dst:
+            shutil.copyfileobj(handle_src, handle_dst)
+    else:
+        shutil.copy2(src, dst)
+
+
+@click.command(context_settings={"help_option_names": ["-h", "--help"]})
+@click.option(
+    "--predicted-dir",
+    type=click.Path(path_type=Path, exists=True, file_okay=False),
+    required=True,
+    help="Directory containing nested AlphaFold predictions (top-level ENSP* folders).",
+)
+@click.option(
+    "--output-dir",
+    type=click.Path(path_type=Path, file_okay=False),
+    required=True,
+    help="Directory where flattened PDBs will be written.",
+)
+def cli(predicted_dir: Path, output_dir: Path) -> None:
+    """Collect ranked_0 PDBs from nested outputs and rename them by ENSP."""
+    predicted_dir = predicted_dir.expanduser().resolve()
+    output_dir = output_dir.expanduser().resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    ensp_folders = sorted(
+        folder for folder in predicted_dir.iterdir() if folder.is_dir() and folder.name.startswith("ENSP")
+    )
+    if not ensp_folders:
+        raise click.ClickException(f"No ENSP* folders found in: {predicted_dir}")
+
+    copied = 0
+    missing = 0
+    for folder in ensp_folders:
+        ensp_id = folder.name
+        ranked = find_ranked_structure(folder)
+        if ranked is None:
+            click.echo(f"[WARNING] {ensp_id}: ranked_0.pdb not found")
+            missing += 1
+            continue
+
+        dst = output_dir / f"{ensp_id}.alphafold.pdb"
+        try:
+            copy_pdb(ranked, dst)
+            copied += 1
+        except OSError as exc:
+            click.echo(f"[WARNING] {ensp_id}: failed to copy {ranked} -> {dst}: {exc}")
+            missing += 1
+
+    click.echo(f"Scanned {len(ensp_folders)} ENSP folders.")
+    click.echo(f"Copied {copied} structures into {output_dir}.")
+    if missing:
+        click.echo(f"Missing/failed: {missing}")
+
+
+if __name__ == "__main__":
+    cli()
+

--- a/tools/preprocessing/update_samplesheet_and_structures.py
+++ b/tools/preprocessing/update_samplesheet_and_structures.py
@@ -239,6 +239,7 @@ def merge_structure_bundles(
     bundle_dirs: Iterable[Path],
     output_dir: Path,
     metadata_map: Optional[pd.DataFrame] = None,
+    master_samplesheet: Optional[pd.DataFrame] = None,
 ) -> pd.DataFrame:
     """Merge multiple ENSP bundles into a single `output_dir` with deduplicated samplesheet."""
     output_dir = ensure_dir(output_dir)
@@ -258,6 +259,7 @@ def merge_structure_bundles(
         raise RuntimeError("No valid bundles provided for merging.")
     combined = pd.concat(merged, ignore_index=True).drop_duplicates(subset=["sequence"])
     combined = attach_metadata(combined, metadata_map)
+    combined = attach_refseq(combined, master_samplesheet)
     combined.to_csv(output_dir / "samplesheet.csv", index=False)
     print(f"Merged {len(merged)} bundles → {len(combined)} unique ENSP entries")
     return combined
@@ -443,6 +445,20 @@ def attach_metadata(df: pd.DataFrame, metadata_map: Optional[pd.DataFrame]) -> p
         df.drop(columns=["symbol", "CGC", "length"], errors="ignore")
         .merge(metadata, on="sequence", how="left")
     )
+
+
+def attach_refseq(df: pd.DataFrame, master_samplesheet: Optional[pd.DataFrame]) -> pd.DataFrame:
+    """Attach the amino-acid sequence column (`refseq`) from the master samplesheet when available."""
+    if master_samplesheet is None or df.empty:
+        return df
+    if "refseq" not in master_samplesheet.columns:
+        return df
+    refseq_map = (
+        master_samplesheet[["sequence", "refseq"]]
+        .dropna(subset=["sequence"])
+        .drop_duplicates(subset=["sequence"])
+    )
+    return df.drop(columns=["refseq"], errors="ignore").merge(refseq_map, on="sequence", how="left")
 
 
 def compute_fasta_lengths(fasta_paths: pd.Series) -> pd.Series:
@@ -753,7 +769,12 @@ def run_pipeline(
         print("No predicted/retrieved bundles available; skipping final merge.")
         return
 
-    merge_structure_bundles(bundles_to_merge, paths.final_bundle_dir, metadata_map)
+    merge_structure_bundles(
+        bundles_to_merge,
+        paths.final_bundle_dir,
+        metadata_map,
+        master_samplesheet=samplesheet,
+    )
     print(f"Final bundle written to {paths.final_bundle_dir}")
 
 


### PR DESCRIPTION
## Summary
New AlphaFold runs can output nested `ENSP*` folders where the top structure is `ranked_0.pdb` (no ENSP in filename), but `update_samplesheet_and_structures.py` `--predicted-dir` expects a flat PDB folder.

Changes:
- Add `parser_alphafold_predictions.py` to scan a `--predicted-dir`, find each `ranked_0.pdb` (or `.gz)`, and copy it to `--output-dir` as `<ENSP_ID>.alphafold.pdb`.
- Ignores non-`ENSP*` folders, skips ENSP folders without a `ranked_0.pdb,` and does not modify the original predictions directory.
- Fix `samplesheet.csv` sorting in `tools/preprocessing/update_samplesheet_and_structures.py` if `--cgc-list-path` is provided.

### Usage
`parser_alphafold_predictions.py --predicted-dir <nested_predictions> --output-dir <flat_pdbs>`