### PR TITLE
fix: cap RaSP ΔΔG download to 4 segments to avoid mirror stalls

### DIFF
--- a/scripts/plotting/stability_change.py
+++ b/scripts/plotting/stability_change.py
@@ -46,7 +46,7 @@ def download_stability_change(path: str,
     try:
         # Download file
         logger.debug(f'Downloading to {file_path}')
-        download_single_file(download_url, file_path, threads)
+        download_single_file(download_url, file_path, min(threads, 4))
         
         # Extract from zip
         logger.debug(f'Extracting {filename}')


### PR DESCRIPTION
## Summary
- `oncodrive3d build-annotations` was stalling indefinitely when downloading the ~8.6 GB RaSP human ΔΔG bundle from `sid.erda.dk`. The host throttles/drops connections when too many segments are opened in parallel, leaving `pypdl` reporting `0.00 MB/s, ETA: 99:59:59` until the socket-read timeout fires.
- The download previously used `min(cores, 8)` segments (inherited from `download_single_file`), which is reliable for AlphaFold/Ensembl mirrors but too aggressive for the erda.dk share hosting RaSP.
- This patch caps the concurrency to `min(threads, 4)` for the RaSP call site only — all other downloads (AlphaFold structures, BioMart, MANE summary) keep their existing behavior.