### PR TITLE
fix: skip ΔΔG step for mouse when --ddg_dir is not provided

### DIFF
--- a/docs/annotations_plotting.md
+++ b/docs/annotations_plotting.md
@@ -35,7 +35,7 @@ Key options:
 
 - `--data_dir` (**required**) – the Oncodrive3D datasets folder built via `oncodrive3d build-datasets`; annotations pull AlphaFold PDBs and metadata from here.
 - `--output_dir` – target directory for the annotation bundle (defaults to `annotations/`; cleaned at each run unless `--yes`).
-- `--ddg_dir` – point to precomputed RaSP ΔΔG predictions to skip the download step (mandatory for mouse because only human RaSP files are hosted).
+- `--ddg_dir` – point to precomputed RaSP ΔΔG predictions to skip the download step. Required for mouse if ΔΔG tracks are desired (only the human RaSP bundle is hosted); when omitted for mouse, the ΔΔG step is skipped with a warning and the rest of the build proceeds normally.
 - `--organism` – select the species recipe (human or mouse) so the correct external resources are queried.
 - `--cores` / `--yes` – control parallelism and disable confirmation prompts when overwriting an existing `output_dir`.
 

--- a/docs/annotations_plotting.md
+++ b/docs/annotations_plotting.md
@@ -56,12 +56,12 @@ annotations/
 ├── pdb_tool_df.tsv
 ├── pfam.tsv
 ├── uniprot_feat.tsv
-├── stability_change/
+├── stability_change/        # optional; absent for mouse builds without --ddg_dir
 │   └── <UNIPROT>_ddg.json
 └── log/
 ```
 
-Keep this directory around—`oncodrive3d plot` expects all of these files.
+Keep this directory around — `oncodrive3d plot` reads the tables above and merges in ΔΔG values when `stability_change/` is present, otherwise the ΔΔG track is omitted from per-gene plots and association analyses.
 
 ---
 

--- a/scripts/plotting/build_annotations.py
+++ b/scripts/plotting/build_annotations.py
@@ -36,14 +36,14 @@ def get_annotations(data_dir,
 
     # # Get ddG
     species = get_species(organism)
-    logger.info("Obtaining stability change..")
+    logger.info("Checking stability change inputs..")
     if species == "Mus musculus" and ddg_dir is None:
         logger.warning(
             "Stability change (ΔΔG) for Mus musculus requires precomputed predictions: "
             "the public RaSP bundle is only hosted for Homo sapiens. Skipping ΔΔG step. "
             "Provide --ddg_dir with mouse RaSP predictions to include ΔΔG tracks."
         )
-    elif species == "Homo sapiens" or species == "Mus musculus":
+    elif species in ("Homo sapiens", "Mus musculus"):
         ddg_output = os.path.join(output_dir, "stability_change")
         os.makedirs(ddg_output, exist_ok=True)
         if ddg_dir is not None:

--- a/scripts/plotting/build_annotations.py
+++ b/scripts/plotting/build_annotations.py
@@ -37,22 +37,28 @@ def get_annotations(data_dir,
     # # Get ddG
     species = get_species(organism)
     logger.info("Obtaining stability change..")
-    if species == "Homo sapiens" or species == "Mus musculus":
+    if species == "Mus musculus" and ddg_dir is None:
+        logger.warning(
+            "Stability change (ΔΔG) for Mus musculus requires precomputed predictions: "
+            "the public RaSP bundle is only hosted for Homo sapiens. Skipping ΔΔG step. "
+            "Provide --ddg_dir with mouse RaSP predictions to include ΔΔG tracks."
+        )
+    elif species == "Homo sapiens" or species == "Mus musculus":
         ddg_output = os.path.join(output_dir, "stability_change")
         os.makedirs(ddg_output, exist_ok=True)
         if ddg_dir is not None:
             # Copy ddG from path
             temp_ddg_path = os.path.join(output_dir, "stability_change_temp")
             copy_dir(source_dir=ddg_dir, destination_dir=temp_ddg_path)
-        else:    
+        else:
             # Download ddG
             temp_ddg_path = download_stability_change(ddg_output, cores)
         logger.info("Completed!")
-        
-        ## TODO: Optimize DDG parsing 
+
+        ## TODO: Optimize DDG parsing
         ##       - only one protein is allocated to one process every time
         ##       - a list of proteins should be allocated instead
-        
+
         # Parsing DDG
         logger.info("Parsing stability change..")
         parse_ddg_rasp(temp_ddg_path, ddg_output, cores)


### PR DESCRIPTION
## Summary
- `build-annotations --organism mouse` without `--ddg_dir` was silently downloading the 8.6 GB **human** RaSP bundle (URL is hardcoded). The resulting JSONs were keyed by human UniProt IDs, so downstream `oncodrive3d plot` silently produced empty ΔΔG tracks for every mouse gene.
- Now the ΔΔG step is skipped for mouse when `--ddg_dir` is omitted, with a clear warning. Other steps (PDB_Tool / Pfam / UniProt) are unchanged. `oncodrive3d plot` already tolerates a missing `stability_change/` directory.
- Docs updated to mark `stability_change/` as optional.
