### PR TITLE
fix: catch missing score_ml at ΔΔG validation + remove dead extract_mut

### DIFF
--- a/scripts/plotting/stability_change.py
+++ b/scripts/plotting/stability_change.py
@@ -104,15 +104,6 @@ def append_ddg_to_dict(ddg_dict, df, frag=False):
     return ddg_dict
 
 
-def extract_mut(variant_str, pattern):
-
-    match = pattern.match(variant_str)
-    pos = match.group(2)
-    alt = match.group(3)
-
-    return pos, alt
-
-
 def save_json(path_dir, uni_id, dictionary):
     
     with open(os.path.join(path_dir, f"{uni_id}_ddg.json"), "w") as json_file:
@@ -159,7 +150,10 @@ def _validate_protein_ddg(canonical_seq, csv_paths, wt_mismatch_threshold):
     n_mismatch = 0
     for path_prot in csv_paths:
         try:
-            df = pd.read_csv(path_prot, usecols=["variant"])
+            # Load score_ml too so a CSV missing that column fails validation
+            # here (clean log) rather than later inside the worker (multiprocessing
+            # KeyError with a swallowed traceback).
+            df = pd.read_csv(path_prot, usecols=["variant", "score_ml"])
         except Exception as e:
             return False, f"csv_unreadable: {type(e).__name__}"
         for variant in df["variant"]:


### PR DESCRIPTION
## Summary
Two small fixes addressing leftover code-review nits from the previous ΔΔG PR.

- **`_validate_protein_ddg` now opens CSVs with `usecols=["variant", "score_ml"]`** (was just `["variant"]`). A CSV missing the `score_ml` column previously passed validation and then crashed later inside `append_ddg_to_dict` with a multiprocessing-swallowed `KeyError`. The failure now surfaces cleanly at validation time as `csv_unreadable: ValueError`.
- **Deleted `extract_mut`** — dead code since `append_ddg_to_dict` was switched to inline `_VARIANT_RE.match()`. Two reviewers flagged it; zero callers in the codebase.