### PR TITLE
docs: tighten references; align chimerax-plot defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,8 @@ This step builds the datasets necessary for Oncodrive3D to run the 3D clustering
 > [!WARNING]
 > This step is time- and resource-intensive: it downloads and processes large amounts of structural data. Ensure adequate disk space, CPU, and a reliable internet connection (AlphaFold, Ensembl, Pfam, and other resources are fetched on demand).
 
-> [!NOTE]
-> Predicted Aligned Error (PAE) files for older AlphaFold DB versions (e.g., v4) are no longer hosted after 2025. If you need PAE for an older AF version, download and supply them locally via `--custom_pae_dir`.  
-> MANE structures are available only in AlphaFold DB v4, while non-MANE builds default to v6. Since MANE mode forces v4 structures, you should also supply the corresponding PAE files through `--custom_pae_dir`.
+> [!WARNING]
+> MANE builds force AlphaFold DB v4 structures (non-MANE builds default to v6). PAE files for v4 are no longer hosted after 2025, so `--mane` runs must supply them locally via `--custom_pae_dir`.
 
 > [!NOTE]
 > The first time that you run Oncodrive3D building dataset step with a given reference genome, it will download it from our servers. By default the downloaded datasets go to `~/.bgdata`. If you want to move these datasets to another folder you have to define the system environment variable `BGDATA_LOCAL` with an export command.
@@ -130,7 +129,10 @@ Examples:
 See `oncodrive3d run --help` for all options.
 
 > [!WARNING]
-> Human datasets built with the default settings pin canonical transcript metadata to the January 2024 Ensembl archive (release 111 / GENCODE v45). To maximize the number of matching transcripts between your input mutations and Oncodrive3D's structures, either annotate your variants with the same Ensembl/GENCODE release, or pass the unfiltered VEP output together with `--o3d_transcripts --use_input_symbols`.
+> Human datasets built with the default settings pin canonical transcript metadata to the January 2024 Ensembl archive (release 111 / GENCODE v45). Annotate input variants with the same Ensembl/GENCODE release to avoid transcript-ID mismatches.
+
+> [!TIP]
+> To maximize the number of matching transcripts between your input mutations and Oncodrive3D's structures, supply the unfiltered VEP output as input along with `--o3d_transcripts --use_input_symbols`.
 
 ### Handling Heterogeneous Sequencing Depth
 

--- a/README.md
+++ b/README.md
@@ -12,23 +12,21 @@ The method leverages **AlphaFold 2-predicted protein structures** and Predicted 
 
 ## Requirements
 
-Before you begin, ensure **Python 3.10 or later** is installed on your system.  
-Additionally, you may need to install additional development tools. Depending on your environment, you can choose one of the following methods:
+Python 3.10+ is required. Some systems also need a C/C++ toolchain:
 
-- If you have sudo privileges:
+- With sudo privileges:
 
    ```bash
    sudo apt install build-essential
    ```
 
-- For HPC cluster environment, it is recommended to use [Conda](https://docs.conda.io/projects/conda/en/latest/user-guide/install/index.html) (or [Mamba](https://mamba.readthedocs.io/en/latest/)):
+- On HPC clusters, [Conda](https://docs.conda.io/projects/conda/en/latest/user-guide/install/index.html) (or [Mamba](https://mamba.readthedocs.io/en/latest/)) is recommended:
 
    ```bash
    conda create -n o3d python=3.10.0
    conda activate o3d
    conda install -c conda-forge gxx gcc libxcrypt clang zlib
    ```
-
 
 ## Installation
 
@@ -60,9 +58,7 @@ Additionally, you may need to install additional development tools. Depending on
 This step builds the datasets necessary for Oncodrive3D to run the 3D clustering analysis. It is required once after installation or whenever you need to generate datasets for a different organism or apply a specific threshold to define amino acid contacts.
 
 > [!WARNING]
-> This step is highly time- and resource-intensive, requiring a significant amount of free disk space and computational power. It will download and process a large amount of data. Ensure sufficient resources are available before proceeding, as insufficient capacity may result in extended runtimes or processing failures.
->
-> Reliable internet access is required because AlphaFold structures, Ensembl annotations, Pfam files, and other resources are downloaded on demand during the build.
+> This step is time- and resource-intensive: it downloads and processes large amounts of structural data. Ensure adequate disk space, CPU, and a reliable internet connection (AlphaFold, Ensembl, Pfam, and other resources are fetched on demand).
 
 > [!WARNING]
 > Human datasets built with the default settings pull canonical transcript metadata from the January 2024 Ensembl archive (release 111 / GENCODE v45). For maximum compatibility, annotate your input variants with the same Ensembl/Gencode release or supply the unfiltered VEP output together with `--o3d_transcripts --use_input_symbols`.
@@ -74,73 +70,30 @@ This step builds the datasets necessary for Oncodrive3D to run the 3D clustering
 > [!NOTE]
 > The first time that you run Oncodrive3D building dataset step with a given reference genome, it will download it from our servers. By default the downloaded datasets go to `~/.bgdata`. If you want to move these datasets to another folder you have to define the system environment variable `BGDATA_LOCAL` with an export command.
 
-```
+```text
 Usage: oncodrive3d build-datasets [OPTIONS]
 
 Examples:
-  Basic build:
+  Basic build (human):
     oncodrive3d build-datasets -o <build_folder>
-  
+
   Build with MANE Select transcripts:
     oncodrive3d build-datasets -o <build_folder> --mane
 
-Options:
-  -o, --output_dir PATH           Path to the directory where the output files will be saved. 
-                                  Default: ./datasets/
-  -s, --organism TEXT             Specifies the organism (`human` or `mouse`; also accepts `Homo sapiens` / `Mus musculus`). 
-                                  Default: Homo sapiens
-  -m, --mane                      Use structures predicted from MANE Select transcripts 
-                                  (applicable to Homo sapiens only).
-  -M, --mane_only                 Use only structures predicted from MANE Select transcripts
-                                  (applicable to Homo sapiens only).
-  -C, --custom_mane_pdb_dir PATH  Path to directory containing custom MANE PDB structures (requires --mane_only).
-                                  Default: None
-      --custom_pae_dir PATH       Path to directory containing pre-downloaded PAE JSON files.
-                                  The directory will be copied into the build as `pae/`.
-                                  Default: None
-  -f, --custom_mane_metadata_path Path to a dataframe (typically a samplesheet.csv) including 
-                                  Ensembl IDs and sequences of the custom pdbs.
-                                  Default: None
-  -d, --distance_threshold INT    Distance threshold (Å) for defining residues contacts. 
-                                  Default: 10
-  -c, --cores INT                 Number of CPU cores for computation. 
-                                  Default: All available CPU cores
-  --af_version INT                AlphaFold DB version for non-MANE builds (MANE uses v4).
-                                  Default: 6
-  -y, --yes                       Run without interactive prompts.
-  -v, --verbose                   Enables verbose output.
-  -h, --help                      Show this message and exit.  
+  Build mouse datasets:
+    oncodrive3d build-datasets -o <build_folder> -s mouse
 ```
+
+See `oncodrive3d build-datasets --help` for all options.
 
 For more information on the output of this step, please refer to the [Building Datasets Output Documentation](https://github.com/bbglab/oncodrive3d/tree/master/docs/build_output.md).
 
 > [!TIP]
-> ### Increasing MANE Structural Coverage
-> To maximize structural coverage of **MANE Select transcripts**, you can [predict missing structures locally and integrate them into Oncodrive3D](tools/preprocessing/README.md) using:
->
-> - `tools/preprocessing/prepare_samplesheet.py`: a standalone utility that:
->   - Retrieves the full MANE entries from NCBI.
->   - Identifies proteins missing from the AlphaFold MANE dataset.
->   - Generates:
->     - A `samplesheet.csv` with Ensembl protein IDs, FASTA paths, and optional sequences.
->     - Individual FASTA files for each missing protein.
->
-> - `tools/preprocessing/update_samplesheet_and_structures.py`: takes the samplesheet folder produced above and:
->   - Reuses canonical AlphaFold structures when possible to shrink the nf-core input.
->   - Ingests nf-core/proteinfold predictions and keeps the `missing/` set up to date.
->   - Generates a `final_bundle/samplesheet.csv` plus `final_bundle/pdbs/`, ready to be passed to `oncodrive3d build-datasets --mane_only` via `--custom_mane_metadata_path` and `--custom_mane_pdb_dir`.
->
-> - When invoking `oncodrive3d build-datasets`, supply:
->   - `--custom_mane_pdb_dir`: use this to provide your own predicted PDB structures (e.g., from [nf-core/proteinfold](https://nf-co.re/proteinfold/1.1.1/) or `final_bundle/pdbs/` produced by `update_samplesheet_and_structures.py`).
->   - `--custom_mane_metadata_path`: path to the corresponding `samplesheet.csv` (e.g., `final_bundle/samplesheet.csv`).
->
-> See the documentation of [MANE Preprocessing Toolkit](tools/preprocessing/README.md) for the full workflow to expand coverage of the MANE associated structures.
+> To extend MANE Select structural coverage beyond the AlphaFold MANE bundle, see the [MANE Preprocessing Toolkit](tools/preprocessing/README.md).
 
+## Running 3D Clustering Analysis
 
-
-## Running 3D clustering Analysis
-
-For in-depth information on how to obtain the required input data and for comprehensive information about the output, please refer to the [Input and Output Documentation](https://github.com/bbglab/oncodrive3d/tree/master/docs/run_input_output.md) of the 3D clustering analysis.  
+See the [Input and Output Documentation](docs/run_input_output.md) for details on inputs and outputs.
 
 ### Input
 
@@ -163,61 +116,21 @@ Please refer to these examples to understand the expected format and structure o
   
 - **Residue-level output**: CSV file (`<cohort>.3d_clustering_pos.csv`) containing the results of the analysis at the level of mutated residues. Each row corresponds to a mutated position within a gene and includes detailed information for each potential mutational cluster.
 
-
 ### Usage
 
-```
+```text
 Usage: oncodrive3d run [OPTIONS]
 
 Examples:
   Basic run:
     oncodrive3d run -i <input_maf> -p <mut_profile> -d <build_folder> -C <cohort_name>
-  
-  Example of run using VEP output as input and MANE Select transcripts:
+
+  Run using VEP output as input and MANE Select transcripts:
     oncodrive3d run -i <input_vep> -p <mut_profile> -d <build_folder> -C <cohort_name> \
                     --o3d_transcripts --use_input_symbols --mane
-
-Options:
-  -i, --input_path PATH            Path to the input file (MAF or VEP output) containing the 
-                                   annotated mutations for the cohort. [required]
-  -p, --mut_profile_path PATH      Path to the JSON file specifying the cohort's mutational 
-                                   profile (192 key-value pairs).
-  -m, --mutability_config_path PATH
-                                   Path to the JSON file with information on mutability, used when
-                                   mutation calls originate from cohorts with highly heterogeneous
-                                   sequencing depth across sites.
-  -o, --output_dir PATH            Path to the output directory for results. 
-                                   Default: ./output/
-  -d, --data_dir PATH              Path to the directory containing the datasets built in the 
-                                   building datasets step. 
-                                   Default: ./datasets/
-  -n, --n_iterations INT           Number of densities to be simulated.
-                                   Default: 10000
-  -a, --alpha FLOAT                Significance threshold for residue and gene p-values.
-                                   Default: 0.01
-  -c, --cores INT                  Number of CPU cores to use. 
-                                   Default: All available CPU cores
-  -s, --seed INT                   Random seed for reproducibility.
-  -v, --verbose                    Enables verbose output.
-  -t, --cancer_type STR            Cancer type to include as metadata in the output file.
-  -C, --cohort STR                 Cohort name for metadata and output file naming. 
-  --no_fragments                   Disable processing of fragmented (AF-F) proteins.
-  --only_processed                 Include only processed genes in the output.
-  --thr_mapping_issue FLOAT        Threshold for the ratio of mutations with mapping issues 
-                                   (out of structure, WT mismatch, zero mutability). A value 
-                                   of 1 disables filtering mismatching mutations.
-                                   Default: 0.1
-  -P, --cmap_prob_thr FLOAT        Threshold for defining residues contacts based on distance 
-                                   on predicted structure and predicted aligned error (PAE). 
-                                   Default: 0.5
-  --mane                           Prioritizes MANE Select transcripts when multiple 
-                                   structures map to the same gene symbol.
-  --o3d_transcripts                Filters mutations including only transcripts in Oncodrive3D 
-                                   built datasets (requires VEP output as input file).
-  --use_input_symbols              Update HUGO symbols in Oncodrive3D built datasets using the 
-                                   input file's entries (requires VEP output as input file).
-  -h, --help                       Show this message and exit.  
 ```
+
+See `oncodrive3d run --help` for all options.
 
 > [!TIP]
 > To maximize the number of matching transcripts between the input mutations and the AlphaFold predicted structures used by Oncodrive3D, it is recommended to use the unfiltered output of VEP (including all possible transcripts) as input, along with the flags `--o3d_transcripts` `--use_input_symbols` in the `oncodrive3d run` command.
@@ -251,74 +164,18 @@ Check the output in the `test/output/` directory to ensure the analysis complete
 
 ## Building Annotations & Plotting
 
-Oncodrive3D ships with an optional plotting pipeline: run `oncodrive3d build-annotations` once to cache structural/functional tracks, then use `oncodrive3d plot` and/or `chimerax-plot` to generate plots and tables that help interpret the clustering signal and distinguish real biology from artifacts.  
+Oncodrive3D ships with an optional plotting pipeline: run `oncodrive3d build-annotations` once to cache structural/functional tracks, then use `oncodrive3d plot` and/or `chimerax-plot` to generate plots and tables that help interpret the clustering signal and distinguish real biology from artifacts.
 
-Please refer to [Annotation & plotting workflow](docs/annotations_plotting.md) for prerequisites, command examples, and output descriptions.
+See the [Annotation & plotting workflow](docs/annotations_plotting.md) for prerequisites, usage examples, and output descriptions.
 
 ## Parallel Processing on Multiple Cohorts
 
-This repository provides a [Nextflow](https://www.nextflow.io/) pipeline to run Oncodrive3D in parallel across multiple cohorts, enabling efficient, reproducible and scalable analysis across datasets.  
-
-For more information, refer to the [Oncodrive3D Pipeline](https://github.com/bbglab/oncodrive3d/tree/master/oncodrive3d_pipeline/) documentation.
-
-### Usage
-
-> [!NOTE]
-> When using the Nextflow script, ensure that your input files are organized in the following directory structure (you only need either the `maf/` or `vep/` directory):
-> 
-> ```plaintext
-> input/
->   ├── maf/
->   │   └── <cohort>.in.maf
->   ├── vep/
->   │   └── <cohort>.vep.tsv.gz
->   └── mut_profile/
->       └── <cohort>.sig.json
-> ```
-> 
-> - `maf/`: Contains mutation files with the `.in.maf` extension.
-> - `vep/`: Contains VEP annotation files with the `.vep.tsv.gz` extension, which include annotated mutations with all possible transcripts.
-> - `mut_profile/`: Contains mutational profile files with the `.sig.json` extension.
-
-```
-Usage: nextflow run main.nf [OPTIONS]
-
-Example of run using VEP output as input and MANE Select transcripts:
-  nextflow run main.nf -profile container --data_dir <build_folder> --indir <input> \
-                       --vep_input true --mane true
-  
-Options:
-  --indir PATH                    Path to the input directory including the subdirectories 
-                                  `maf/` or `vep/` and `mut_profile/`. 
-  --outdir PATH                   Path to the output directory. 
-                                  Default: run_<timestamp>/
-  --cohort_pattern STR            Pattern expression to filter specific files within the 
-                                  input directory (e.g., 'TCGA*' select only TCGA cohorts). 
-                                  Default: *
-  --data_dir PATH                 Path to the Oncodrive3D datasets directory, which includes 
-                                  the files compiled during the building datasets step.
-                                  Default: ${baseDir}/datasets/
-  --max_running INT               Maximum number of cohorts to process in parallel.
-                                  Default: 5
-  --cores INT                     Number of CPU cores used to process each cohort. 
-                                  Default: 10
-  --memory STR                    Amount of memory allocated for processing each cohort. 
-                                  Default: 70GB
-  --vep_input BOOL                Use `vep/` subdir as input and select transcripts matching 
-                                  the Ensembl transcript IDs in Oncodrive3D built datasets. 
-                                  Default: false
-  --mane BOOL                     Prioritize structures corresponding to MANE transcripts if 
-                                  multiple structures are associated to the same gene.
-                                  Default: false
-  --seed INT                      Seed value for reproducibility.
-                                  Default: 128
-```
-
+Oncodrive3D ships with a [Nextflow](https://www.nextflow.io/) pipeline for running multiple cohorts in parallel. See the [Oncodrive3D Pipeline documentation](oncodrive3d_pipeline/README.md) for setup, input layout, and options.
 
 ## License
 
 Oncodrive3D is available to the general public subject to certain conditions described in its [LICENSE](LICENSE).
 
+## Citation
 
-## Citation 
 If you use Oncodrive3D in your research, please cite the original paper: [Oncodrive3D: fast and accurate detection of structural clusters of somatic mutations under positive selection](https://academic.oup.com/nar/article/53/15/gkaf776/8234003).

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Examples:
 
 See `oncodrive3d build-datasets --help` for all options.
 
-For more information on the output of this step, please refer to the [Building Datasets Output Documentation](https://github.com/bbglab/oncodrive3d/tree/master/docs/build_output.md).
+For more information on the output of this step, please refer to the [Building Datasets Output Documentation](docs/build_output.md).
 
 > [!TIP]
 > To extend MANE Select structural coverage beyond the AlphaFold MANE bundle, see the [MANE Preprocessing Toolkit](tools/preprocessing/README.md).
@@ -104,7 +104,7 @@ See the [Input and Output Documentation](docs/run_input_output.md) for details o
 - **<mut_profile>** (`optional`): Dictionary including the normalized frequencies of mutations (*values*) in every possible trinucleotide context (*keys*), such as 'ACA>A', 'ACC>A', and so on.
 
 > [!NOTE] 
-> Examples of the input files are available in the [Test Input Folder](https://github.com/bbglab/oncodrive3d/tree/master/test/input).  
+> Examples of the input files are available in the [Test Input Folder](test/input).  
 Please refer to these examples to understand the expected format and structure of the input files.
 
 > [!NOTE]

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ This step builds the datasets necessary for Oncodrive3D to run the 3D clustering
 > This step is time- and resource-intensive: it downloads and processes large amounts of structural data. Ensure adequate disk space, CPU, and a reliable internet connection (AlphaFold, Ensembl, Pfam, and other resources are fetched on demand).
 
 > [!WARNING]
-> MANE builds force AlphaFold DB v4 structures (non-MANE builds default to v6). PAE files for v4 are no longer hosted after 2025, so `--mane` runs must supply them locally via `--custom_pae_dir`.
+> MANE builds force AlphaFold DB v4 structures (non-MANE builds default to v6). PAE files for v4 are no longer hosted after 2025, so MANE builds without `--custom_pae_dir` fall back to binary contact maps. To keep PAE-weighted probability maps, supply precomputed v4 PAE files via `--custom_pae_dir`.
 
 > [!NOTE]
 > The first time that you run Oncodrive3D building dataset step with a given reference genome, it will download it from our servers. By default the downloaded datasets go to `~/.bgdata`. If you want to move these datasets to another folder you have to define the system environment variable `BGDATA_LOCAL` with an export command.

--- a/README.md
+++ b/README.md
@@ -60,9 +60,6 @@ This step builds the datasets necessary for Oncodrive3D to run the 3D clustering
 > [!WARNING]
 > This step is time- and resource-intensive: it downloads and processes large amounts of structural data. Ensure adequate disk space, CPU, and a reliable internet connection (AlphaFold, Ensembl, Pfam, and other resources are fetched on demand).
 
-> [!WARNING]
-> Human datasets built with the default settings pull canonical transcript metadata from the January 2024 Ensembl archive (release 111 / GENCODE v45). For maximum compatibility, annotate your input variants with the same Ensembl/Gencode release or supply the unfiltered VEP output together with `--o3d_transcripts --use_input_symbols`.
-
 > [!NOTE]
 > Predicted Aligned Error (PAE) files for older AlphaFold DB versions (e.g., v4) are no longer hosted after 2025. If you need PAE for an older AF version, download and supply them locally via `--custom_pae_dir`.  
 > MANE structures are available only in AlphaFold DB v4, while non-MANE builds default to v6. Since MANE mode forces v4 structures, you should also supply the corresponding PAE files through `--custom_pae_dir`.
@@ -132,8 +129,8 @@ Examples:
 
 See `oncodrive3d run --help` for all options.
 
-> [!TIP]
-> To maximize the number of matching transcripts between the input mutations and the AlphaFold predicted structures used by Oncodrive3D, it is recommended to use the unfiltered output of VEP (including all possible transcripts) as input, along with the flags `--o3d_transcripts` `--use_input_symbols` in the `oncodrive3d run` command.
+> [!WARNING]
+> Human datasets built with the default settings pin canonical transcript metadata to the January 2024 Ensembl archive (release 111 / GENCODE v45). To maximize the number of matching transcripts between your input mutations and Oncodrive3D's structures, either annotate your variants with the same Ensembl/GENCODE release, or pass the unfiltered VEP output together with `--o3d_transcripts --use_input_symbols`.
 
 ### Handling Heterogeneous Sequencing Depth
 

--- a/docs/annotations_plotting.md
+++ b/docs/annotations_plotting.md
@@ -121,8 +121,7 @@ See `oncodrive3d plot --help` for all options.
 
 **Worth knowing:**
 
-- All input files (gene/pos results, `--maf_path`, `--miss_prob_path`, `--seq_df_path`) must come from the same `oncodrive3d run` invocation; `--datasets_dir` and `--annotations_dir` must be the same pair used during that run. Any mismatch yields empty plots or missing-track errors.
-- `--maf_for_nonmiss_path` is optional and points to the **original** MAF (not the processed one); supplying it enables the non-missense track.
+- `--maf_path` is the **processed missense-only** TSV (`<cohort>.mutations.processed.tsv`) from `oncodrive3d run`. `--maf_for_nonmiss_path` is optional and takes the **original** MAF (before processing) — supply it to enable the non-missense track. All other input files (gene/pos results, `--miss_prob_path`, `--seq_df_path`, `--datasets_dir`, `--annotations_dir`) must come from that same `oncodrive3d run` invocation; mismatch yields empty plots or missing-track errors.
 - `--lst_summary_tracks` / `--lst_gene_tracks` accept comma-separated track names; pair them with `--lst_*_hratios` to redistribute vertical space.
 
 During execution (`scripts/plotting/plot.py`):

--- a/docs/annotations_plotting.md
+++ b/docs/annotations_plotting.md
@@ -40,7 +40,8 @@ See `oncodrive3d build-annotations --help` for all options.
 
 **Worth knowing:**
 
-- `--ddg_dir` must point to a folder of RaSP-style CSVs (columns `variant` and `score_ml`; UniProt accession auto-detected anywhere in the filename, any separator). Required for mouse if ΔΔG tracks are desired — the public RaSP bundle is human-only; omitting it for mouse skips ΔΔG with a warning.
+- ΔΔG predictions default to the public RaSP bundle (computed against AlphaFold v4 human structures). For datasets built with a different AF version, residue-level mismatches are filtered during validation (see `--ddg_mismatch_threshold` below).
+- `--ddg_dir` overrides the default download with a folder of RaSP-style CSVs (columns `variant` and `score_ml`; UniProt accession auto-detected anywhere in the filename, any separator). Required for non-human organisms — the public bundle is human-only; omitting `--ddg_dir` for mouse skips ΔΔG with a warning. To generate predictions yourself on CPUs, see [bbglab/rasp_cpu](https://github.com/bbglab/rasp_cpu).
 - `--ddg_mismatch_threshold` (default `0.1`) drops a protein if its wild-type residues disagree with the canonical UniProt sequence above this fraction. Set to `1.0` to disable the WT-mismatch check (positions outside the canonical sequence still drop the protein).
 - If `--output_dir` exists and isn't empty, you're prompted before its contents are cleaned (excluding `log/`); pass `--yes` to auto-confirm.
 

--- a/docs/annotations_plotting.md
+++ b/docs/annotations_plotting.md
@@ -58,7 +58,7 @@ See `oncodrive3d build-annotations --help` for all options.
 
 **Worth knowing:**
 
-- ΔΔG predictions default to the public RaSP bundle (computed against AlphaFold v4 human structures). For datasets built with a different AF version, residue-level mismatches are filtered during validation (see `--ddg_mismatch_threshold` below).
+- ΔΔG predictions default to the public RaSP bundle (computed against the canonical AlphaFold v4 human proteome — not the MANE bundle). For datasets built with a different AF version, residue-level mismatches are filtered during validation (see `--ddg_mismatch_threshold` below).
 - `--ddg_dir` overrides the default download with a folder of RaSP-style CSVs (columns `variant` and `score_ml`; UniProt accession auto-detected anywhere in the filename, any separator). For non-human organisms the public bundle doesn't apply, so without `--ddg_dir` the ΔΔG step is skipped with a warning — other annotations build normally. To generate predictions yourself on CPUs, see [bbglab/rasp_cpu](https://github.com/bbglab/rasp_cpu).
 - `--ddg_mismatch_threshold` (default `0.1`) drops a protein if its wild-type residues disagree with the canonical UniProt sequence above this fraction. Set to `1.0` to disable the WT-mismatch check (positions outside the canonical sequence still drop the protein).
 - If `--output_dir` exists and isn't empty, you're prompted before its contents are cleaned (excluding `log/`); pass `--yes` to auto-confirm.

--- a/docs/annotations_plotting.md
+++ b/docs/annotations_plotting.md
@@ -32,7 +32,7 @@ oncodrive3d build-annotations -d <build_folder> -o <annot_folder>
 # With a MANE-built dataset:
 oncodrive3d build-annotations -d <mane_build_folder> -o <annot_folder>
 
-# Mouse (custom ΔΔG predictions required):
+# Mouse with custom ΔΔG predictions (omit --ddg_dir to skip the ΔΔG step):
 oncodrive3d build-annotations -d <build_folder> -o <annot_folder> -s mouse --ddg_dir <ddg_path>
 ```
 

--- a/docs/annotations_plotting.md
+++ b/docs/annotations_plotting.md
@@ -41,7 +41,7 @@ See `oncodrive3d build-annotations --help` for all options.
 **Worth knowing:**
 
 - ΔΔG predictions default to the public RaSP bundle (computed against AlphaFold v4 human structures). For datasets built with a different AF version, residue-level mismatches are filtered during validation (see `--ddg_mismatch_threshold` below).
-- `--ddg_dir` overrides the default download with a folder of RaSP-style CSVs (columns `variant` and `score_ml`; UniProt accession auto-detected anywhere in the filename, any separator). Required for non-human organisms — the public bundle is human-only; omitting `--ddg_dir` for mouse skips ΔΔG with a warning. To generate predictions yourself on CPUs, see [bbglab/rasp_cpu](https://github.com/bbglab/rasp_cpu).
+- `--ddg_dir` overrides the default download with a folder of RaSP-style CSVs (columns `variant` and `score_ml`; UniProt accession auto-detected anywhere in the filename, any separator). For non-human organisms the public bundle doesn't apply, so without `--ddg_dir` the ΔΔG step is skipped with a warning — other annotations build normally. To generate predictions yourself on CPUs, see [bbglab/rasp_cpu](https://github.com/bbglab/rasp_cpu).
 - `--ddg_mismatch_threshold` (default `0.1`) drops a protein if its wild-type residues disagree with the canonical UniProt sequence above this fraction. Set to `1.0` to disable the WT-mismatch check (positions outside the canonical sequence still drop the protein).
 - If `--output_dir` exists and isn't empty, you're prompted before its contents are cleaned (excluding `log/`); pass `--yes` to auto-confirm.
 

--- a/docs/annotations_plotting.md
+++ b/docs/annotations_plotting.md
@@ -42,11 +42,11 @@ See `oncodrive3d build-annotations --help` for all options.
 
 - `--ddg_dir` must point to a folder of RaSP-style CSVs (columns `variant` and `score_ml`; UniProt accession auto-detected anywhere in the filename, any separator). Required for mouse if ΔΔG tracks are desired — the public RaSP bundle is human-only; omitting it for mouse skips ΔΔG with a warning.
 - `--ddg_mismatch_threshold` (default `0.1`) drops a protein if its wild-type residues disagree with the canonical UniProt sequence above this fraction. Set to `1.0` to disable the WT-mismatch check (positions outside the canonical sequence still drop the protein).
-- `--output_dir` is cleaned at each run unless `--yes` is passed.
+- If `--output_dir` exists and isn't empty, you're prompted before its contents are cleaned (excluding `log/`); pass `--yes` to auto-confirm.
 
 What happens internally (`scripts/plotting/build_annotations.py` and helpers):
 
-1. **Cleanup** – the target directory is emptied (except for `log/`) unless `--yes` is provided.
+1. **Cleanup** – if the target directory exists and is non-empty, you're prompted before cleaning (preserving `log/`); `--yes` auto-confirms.
 2. **Stability change (ΔΔG)** – RaSP predictions are downloaded (human) or read from `--ddg_dir`. Each protein is parsed into `{position: {ALT: ddg}}` (averaging across fragments) and validated against the canonical sequence from `seq_for_mut_prob.tsv`; proteins failing validation are dropped with a warning. Within a kept protein, positions with no prediction surface as `NaN` (not `0.0`) so plots show gaps, the annotated CSV distinguishes "no data" from "neutral mutation", and the logistic regression restricts itself to real measurements.
 3. **PDB features** – AlphaFold structures are decompressed and sent through `PDB_Tool`, producing `.feature` files that are then parsed into `pdb_tool_df.tsv` with residue-level secondary structure (`SSE`) and relative accessibility (`pACC`).
 4. **Pfam domains** – Pfam coordinates are pulled from the Ensembl BioMart archive plus the Pfam ID database, merged with Oncodrive3D’s sequence metadata, and written to `pfam.tsv`.
@@ -158,7 +158,7 @@ See `oncodrive3d chimerax-plot --help` for all options.
 - `--chimerax_bin` defaults to `/usr/bin/chimerax`; override it if ChimeraX is installed elsewhere or running in a container.
 - `--pixel_size` controls resolution — smaller values produce larger images (default `0.08`).
 - `--cluster_ext` displays extended clusters (mutations that contribute to but don't directly form significant clusters).
-- `--af_version` must match the AlphaFold build behind your datasets (default `4`) so structure filenames resolve correctly.
+- `--af_version` defaults to `6` (matching `build-datasets`). Pass it only if your datasets were built with a different version (e.g., `--af_version 4` for MANE builds).
 
 ---
 

--- a/docs/annotations_plotting.md
+++ b/docs/annotations_plotting.md
@@ -26,24 +26,28 @@ This document describes the prerequisites, the intermediate files that are produ
 Run once per dataset (or whenever you update AlphaFold structures):
 
 ```bash
-oncodrive3d build-annotations \
-  --data_dir /path/to/datasets \
-  --output_dir /path/to/annotations
+# Default (Homo sapiens, public RaSP ΔΔG):
+oncodrive3d build-annotations -d <build_folder> -o <annot_folder>
+
+# With a MANE-built dataset:
+oncodrive3d build-annotations -d <mane_build_folder> -o <annot_folder>
+
+# Mouse (custom ΔΔG predictions required):
+oncodrive3d build-annotations -d <build_folder> -o <annot_folder> -s mouse --ddg_dir <ddg_path>
 ```
 
-Key options:
+See `oncodrive3d build-annotations --help` for all options.
 
-- `--data_dir` (**required**) – the Oncodrive3D datasets folder built via `oncodrive3d build-datasets`; annotations pull AlphaFold PDBs and metadata from here.
-- `--output_dir` – target directory for the annotation bundle (defaults to `annotations/`; cleaned at each run unless `--yes`).
-- `--ddg_dir` – point to precomputed RaSP ΔΔG predictions to skip the download step. Required for mouse if ΔΔG tracks are desired (only the human RaSP bundle is hosted); when omitted for mouse, the ΔΔG step is skipped with a warning and the rest of the build proceeds normally. Files in the directory must be CSVs containing `variant` (e.g. `M1A`) and `score_ml` columns; the UniProt accession is auto-detected anywhere in each filename, so any separator around it (e.g. `cavity_pred_A0A075B6X5_A.csv` or `rasp_pred-A0A075B6X5-F1.csv`) is accepted.
-- `--ddg_mismatch_threshold` – maximum fraction of wild-type residues in a ΔΔG file allowed to disagree with the canonical UniProt sequence before that protein is dropped. Default `0.1` (10%). Proteins with any position outside the canonical sequence are always skipped; the threshold catches isoform/structure mismatches that would otherwise produce misleading ΔΔG numbers. Set to `1.0` to effectively disable the WT-mismatch check (the position-out-of-range check still applies) — useful when you know your predictions came from a different isoform but want to keep the values anyway.
-- `--organism` – select the species recipe (human or mouse) so the correct external resources are queried.
-- `--cores` / `--yes` – control parallelism and disable confirmation prompts when overwriting an existing `output_dir`.
+**Worth knowing:**
+
+- `--ddg_dir` must point to a folder of RaSP-style CSVs (columns `variant` and `score_ml`; UniProt accession auto-detected anywhere in the filename, any separator). Required for mouse if ΔΔG tracks are desired — the public RaSP bundle is human-only; omitting it for mouse skips ΔΔG with a warning.
+- `--ddg_mismatch_threshold` (default `0.1`) drops a protein if its wild-type residues disagree with the canonical UniProt sequence above this fraction. Set to `1.0` to disable the WT-mismatch check (positions outside the canonical sequence still drop the protein).
+- `--output_dir` is cleaned at each run unless `--yes` is passed.
 
 What happens internally (`scripts/plotting/build_annotations.py` and helpers):
 
 1. **Cleanup** – the target directory is emptied (except for `log/`) unless `--yes` is provided.
-2. **Stability change (ΔΔG)** – for human datasets the command downloads RaSP predictions (`scripts/plotting/stability_change.py`). There is no public RaSP bundle for mouse, so mouse runs must supply their own predictions with `--ddg_dir` if ΔΔG tracks are desired. In all cases, whichever folder you point to is parsed into JSON maps `{position: {ALT: ddg}}`, averaging overlapping fragments. Before each protein is written out the parser validates every variant against the canonical UniProt sequence from `seq_for_mut_prob.tsv` and drops the protein (with a warning) if any position lies outside the sequence or if the wild-type mismatch rate exceeds `--ddg_mismatch_threshold`. Downstream `oncodrive3d plot` already tolerates missing per-protein JSONs, so dropped proteins simply omit the ΔΔG track. Within a kept protein, positions for which no prediction is available are surfaced as `NaN` (rather than `0.0`) so per-gene plots show gaps, the annotated CSV's `ΔΔG` column distinguishes "no data" from "neutral mutation", and the univariate logistic regression correctly restricts itself to positions with a real measurement.
+2. **Stability change (ΔΔG)** – RaSP predictions are downloaded (human) or read from `--ddg_dir`. Each protein is parsed into `{position: {ALT: ddg}}` (averaging across fragments) and validated against the canonical sequence from `seq_for_mut_prob.tsv`; proteins failing validation are dropped with a warning. Within a kept protein, positions with no prediction surface as `NaN` (not `0.0`) so plots show gaps, the annotated CSV distinguishes "no data" from "neutral mutation", and the logistic regression restricts itself to real measurements.
 3. **PDB features** – AlphaFold structures are decompressed and sent through `PDB_Tool`, producing `.feature` files that are then parsed into `pdb_tool_df.tsv` with residue-level secondary structure (`SSE`) and relative accessibility (`pACC`).
 4. **Pfam domains** – Pfam coordinates are pulled from the Ensembl BioMart archive plus the Pfam ID database, merged with Oncodrive3D’s sequence metadata, and written to `pfam.tsv`.
 5. **UniProt features** – the EMBL-EBI Proteins API supplies DOMAIN/PTM/SITE/MOTIF/MEMBRANE annotations. They are normalized, merged with Pfam entries, and stored in `uniprot_feat.tsv`.
@@ -94,18 +98,13 @@ oncodrive3d plot \
   --lst_gene_tracks miss_count,miss_prob,score,clusters,ddg,disorder,pacc,ptm,site,sse,pfam
 ```
 
-Key options:
+See `oncodrive3d plot --help` for all options.
 
-- `--gene_result_path`, `--pos_result_path` (**required**) – paths to `<cohort>.3d_clustering_genes.csv` and `<cohort>.3d_clustering_pos.csv` from the same run.
-- `--maf_path` / `--maf_for_nonmiss_path` – `--maf_path` must point to the processed missense-only TSV created by `oncodrive3d run`; `--maf_for_nonmiss_path` is optional and enables the non-missense track if you provide the original MAF.
-- `--miss_prob_path` / `--seq_df_path` – these files (`<cohort>.miss_prob.processed.json` and `<cohort>.seq_df.processed.tsv`) must come from the same run; they carry the per-residue missense probabilities and mapping metadata needed for plotting.
-- `--datasets_dir` / `--annotations_dir` (**required**) – the dataset folder used during the run and the annotation bundle produced by `build-annotations`; mismatched directories cause missing-track errors.
-- `--output_dir` / `--cohort` – where plots/CSVs are written and which cohort label is printed on them.
-- `--fdr` – pass the column name with BH-FDR–adjusted p-values to display corrected values in the plots; defaults to raw `pvalue`.
-- `--lst_summary_tracks` / `--lst_gene_tracks` – comma-separated lists of track names. If you pass custom lists, match them with `--lst_*_hratios` to redistribute vertical space.
-- `--genes` / `--c_genes_only` / `--max_n_genes` – jointly control which genes are rendered. Use `--genes` for explicit symbols, `--c_genes_only` to keep only significant hits, and `--max_n_genes` to cap the total.
-- `--volcano_top_n`, `--summary_fsize_*`, `--gene_fsize_*` – resize summary/association plots; `--volcano_top_n` sets how many associations are annotated in the cohort-level volcano.
-- `--output_csv` / `--output_all_pos` – write the annotated position-level CSV; include non-mutated residues only when `--output_all_pos` is set.
+**Worth knowing:**
+
+- All input files (gene/pos results, `--maf_path`, `--miss_prob_path`, `--seq_df_path`) must come from the same `oncodrive3d run` invocation; `--datasets_dir` and `--annotations_dir` must be the same pair used during that run. Any mismatch yields empty plots or missing-track errors.
+- `--maf_for_nonmiss_path` is optional and points to the **original** MAF (not the processed one); supplying it enables the non-missense track.
+- `--lst_summary_tracks` / `--lst_gene_tracks` accept comma-separated track names; pair them with `--lst_*_hratios` to redistribute vertical space.
 
 During execution (`scripts/plotting/plot.py`):
 
@@ -152,15 +151,14 @@ oncodrive3d chimerax-plot \
   --cluster_ext
 ```
 
-- `--gene_result_path`, `--pos_result_path` (**required**) – gene- and residue-level CSVs from the same run; both are needed to highlight clusters.
-- `--seq_df_path` – must point to the processed sequence dataframe (`<cohort>.seq_df.processed.tsv`), which provides transcript IDs, fragments, and mappings needed to overlay residues on structures.
-- `--datasets_dir` / `--output_dir` – dataset directory supplying AlphaFold models to load in ChimeraX and the destination for PNG/attribute outputs.
-- `--cohort` / `--max_n_genes` – label snapshots and cap the number of genes displayed.
-- `--chimerax_bin` – path to the ChimeraX executable; override this if ChimeraX is installed outside `/usr/bin/chimerax`.
-- `--pixel_size` – controls image resolution (smaller values produce larger images); default `0.08`.
-- `--cluster_ext` / `--fragmented_proteins` – toggles to display extended clusters (mutations that help rescue significance) and to keep AlphaFold-fragmented proteins, respectively.
-- `--transparent_bg` – render PNGs with a transparent background (handy for figure overlays).
-- `--af_version` – specify which AlphaFold build (release tag) your datasets use so the script picks the right structure names (default `4`).
+See `oncodrive3d chimerax-plot --help` for all options.
+
+**Worth knowing:**
+
+- `--chimerax_bin` defaults to `/usr/bin/chimerax`; override it if ChimeraX is installed elsewhere or running in a container.
+- `--pixel_size` controls resolution — smaller values produce larger images (default `0.08`).
+- `--cluster_ext` displays extended clusters (mutations that contribute to but don't directly form significant clusters).
+- `--af_version` must match the AlphaFold build behind your datasets (default `4`) so structure filenames resolve correctly.
 
 ---
 

--- a/docs/annotations_plotting.md
+++ b/docs/annotations_plotting.md
@@ -15,9 +15,27 @@ This document describes the prerequisites, the intermediate files that are produ
 
 1. **Datasets** – `oncodrive3d build-datasets` (or `build-datasets --mane_only`) must have been run already; the plotting stage reads `datasets/pdb_structures`, `seq_for_mut_prob.tsv`, and `confidence.tsv`.
 2. **Python environment** – use the same environment (e.g., `uv` virtualenv) that you rely on for the CLI.
-3. **PDB_Tool binary** – `oncodrive3d build-annotations` invokes the [PDB_Tool](https://github.com/realbigws/PDB_Tool) executable named `PDB_Tool` on `$PATH` to compute per-residue solvent accessibility and secondary structure. Install it or wrap it in a container accessible from the command line.
+3. **PDB_Tool binary** – `oncodrive3d build-annotations` invokes the [PDB_Tool](https://github.com/realbigws/PDB_Tool) executable named `PDB_Tool` on `$PATH` to compute per-residue solvent accessibility and secondary structure. See **Installing PDB_Tool** below for a recipe.
 4. **Internet access** – required to download Pfam annotations, UniProt features, and (if `--ddg_dir` is not set) RaSP ΔΔG predictions. You can point `--ddg_dir` to precomputed RaSP files to skip the download step or to provide in-house predicted scores.
 5. **Disk space** – annotation folders contain many files; keep several GB free.
+
+### Installing PDB_Tool
+
+[PDB_Tool](https://github.com/realbigws/PDB_Tool) compiles from source. If your conda env has no C/C++ toolchain, install one first:
+
+```bash
+conda install -c conda-forge gxx make
+```
+
+Then build and put it on `$PATH`:
+
+```bash
+git clone https://github.com/realbigws/PDB_Tool.git
+cd PDB_Tool
+make -C source_code
+# The Makefile drops the binary at the repo root. Symlink into the active conda env so it resolves via `which PDB_Tool`:
+ln -s "$(pwd)/PDB_Tool" "$CONDA_PREFIX/bin/PDB_Tool"
+```
 
 ---
 

--- a/docs/build_output.md
+++ b/docs/build_output.md
@@ -1,19 +1,25 @@
-# Output
+# Building Datasets Output
 
-After successfully completing this step, the build folder must include the following files and directories:
+After `oncodrive3d build-datasets` completes, the build folder contains:
 
-- **pae/**: Directory including the AlphaFold predicted aligned error (PAE) for any protein of the proteome with a length lower than 2700 amino acids
+```text
+<build_folder>/
+├── pdb_structures/        # AlphaFold PDB files (downloaded bundle + any custom-supplied structures)
+├── pae/                   # AlphaFold Predicted Aligned Error files (.npy, one per UniProt protein — fragmented proteins use the F1 fragment's PAE); absent or partial when PAE is unavailable for the chosen AF version
+├── prob_cmaps/            # Contact probability maps (.npy, one per protein/fragment); F2+ fragments and proteins without PAE fall back to binary contact maps
+├── confidence.tsv         # Per-residue pLDDT scores for every protein in the proteome
+├── seq_for_mut_prob.tsv   # Per-protein metadata: HUGO symbol, HGNC/Ensembl/UniProt IDs, protein and DNA sequence, exon coordinates, trinucleotide contexts
+├── biomart_metadata.tsv   # Ensembl BioMart canonical transcript metadata; used to prioritize when multiple transcripts map to one structure
+└── log/                   # Logs from the build run
+```
 
-- **prob_cmaps/**: Directory including the contact probability map (pCMAPs) for any protein of the proteome
+With `--mane` or `--mane_only`, the folder also contains assets from the AlphaFold MANE overlap bundle (prefixed with `mane_`):
 
-- **confidence.csv**: CSV file including per-residue predicted local distance difference test (pLDDT) score for any protein of the proteome
+```text
+├── mane_summary.txt.gz                # NCBI MANE release summary (cached after first download)
+├── mane_refseq_prot_to_alphafold.csv  # RefSeq protein → AlphaFold MANE mapping (consumed by the MANE preprocessing toolkit)
+└── mane_readme.txt                    # README from the MANE overlap bundle
+```
 
-- **seq_for_mut_prob.csv**: CSV file including HUGO symbol, Uniprot ID, DNA and protein sequences for any proteine of the proteome
-
-- **pdb_structures/**: Directory containing all PDB structure files—both those downloaded from the AlphaFold database and any custom in-house predicted structures (if provided).
-
-- **log/**: Directory containing log files produced during the build-datasets execution.
-
-- **biomart_metadata.csv**: Metadata file from Ensembl BioMart used to prioritize canonical transcripts when multiple transcripts map to the same protein structure.
-
-...
+> [!NOTE]
+> If `--custom_pae_dir` is provided, `pae/` is replaced with the contents of that directory. When PAE files are unavailable (e.g., AF DB v4 after 2025) and no custom PAE is supplied, the build proceeds with binary contact maps in `prob_cmaps/`.

--- a/docs/build_output.md
+++ b/docs/build_output.md
@@ -17,8 +17,9 @@ With `--mane` or `--mane_only`, the folder also contains assets from the AlphaFo
 
 ```text
 ├── mane_summary.txt.gz                # NCBI MANE release summary (cached after first download)
-├── mane_refseq_prot_to_alphafold.csv  # RefSeq protein → AlphaFold MANE mapping (consumed by the MANE preprocessing toolkit)
-└── mane_readme.txt                    # README from the MANE overlap bundle
+├── mane_refseq_prot_to_alphafold.csv  # RefSeq → AlphaFold MANE bundle mapping (consumed by the MANE preprocessing toolkit)
+├── mane_missing.csv                   # MANE entries lacking an AlphaFold MANE structure (consumed by the MANE preprocessing toolkit)
+└── mane_readme.txt                    # README from the AlphaFold MANE overlap bundle
 ```
 
 > [!NOTE]

--- a/docs/run_input_output.md
+++ b/docs/run_input_output.md
@@ -1,4 +1,6 @@
-# Input
+# Input and Output
+
+## Input
 
 Oncodrive3D analyse patterns of somatic mutations at the cohort level, and relies on two primary input files:
 
@@ -11,9 +13,9 @@ Oncodrive3D analyse patterns of somatic mutations at the cohort level, and relie
 
 ---
 
-## Input Mutations
+### Input Mutations
 
-### MAF File
+#### MAF File
 
 A [Mutation Annotation Format (MAF)](https://docs.gdc.cancer.gov/Data/File_Formats/MAF_Format/#introduction) file that encompasses all somatic mutations identified within a specific cohort and their annotations (e.g., annotated by using Ensembl Variant Effect Predictor (VEP)).
 
@@ -32,7 +34,7 @@ The output of VEP should be filtered so that each mutation is mapped to a single
 - **Transcript_ID**: Ensembl ID of the transcript affected by the variant.
 - **HGVSp_Short**: The protein sequence of the variant in HGVS recommended format using 1-letter amino-acid codes.
 
-### VEP File
+#### VEP File
 
 To maximize the number of matching transcripts between the input mutations and the AlphaFold predicted structures used by Oncodrive3D, it is recommended to USE the unfiltered output of VEP (generated using the VEP command described in the [MAF file section](#maf-file)) as input.
 In this case:
@@ -51,7 +53,7 @@ In this case:
 
 ---
 
-## Mutation Profile
+### Mutation Profile
 
 The mutation profile of a cohort rapresents the count or the normalized frequencies of mutations in every possible k-nucleotide (e.g., trinucleotide or pentanucleotide) contexts.
 
@@ -81,7 +83,7 @@ The mutation profile used by Oncodrive3D is a dictionary (json file) including t
 
 The mutation profile can be computed using BGSignature (detailed below) or other bioinformatics softwares.  
 
-### Create the Mutation Profile with BGSignature
+#### Create the Mutation Profile with BGSignature
 
 1. Install BGSignature:
     ```
@@ -113,7 +115,7 @@ To compute the mutation profile with BGSignature two main files are required:
     - `END`
     - `ELEMENT`  
     
-#### Create the Regions File  
+##### Create the Regions File  
 
 A small helper script ([tools/preprocessing/get_regions_file.py](../tools/preprocessing/get_regions_file.py)) generates the regions file via BGReference.
 
@@ -128,13 +130,13 @@ A small helper script ([tools/preprocessing/get_regions_file.py](../tools/prepro
     ```
     Supported genomes: `hg18`, `hg19`, `hg38`, `mm10`, `mm39`. The first argument is the genome build; the second is the k-mer size (typically `3` for trinucleotide contexts).
 
-# Output
+## Output
 
 The `oncodrive3d run command` performs the 3D clustering analysis, generating both main and supplementary output files. The main output files include a gene-level output and a residue-level output, both summarizing the results of the analysis. The supplementary output files include the processed input files and a processed file derived from the Oncodrive3D built datasets, containing information on the genes being analyzed.
 
-## Main Output
+### Main Output
 
-### Gene-level output
+#### Gene-level output
 
 CSV file (`<cohort>.3d_clustering_genes.csv`) containing the results of the analysis at the gene level. The genes (rows) are sorted by ascending order based on significance and deviation from neutrality. 
 
@@ -186,7 +188,7 @@ It includes the following fields:
     - `Fragmented`: The protein structure is predicted as fragments by AlphaFold, and the analysis of fragmented structures is not enabled (`-f`, `--no_fragments`).
 
 
-### Residue-level output
+#### Residue-level output
   
 CSV file (`<cohort>.3d_clustering_pos.csv`) containing the results of the analysis at the level of mutated residues. Each row corresponds to a mutated position within a gene and includes detailed information for each potential mutational cluster.
 
@@ -215,11 +217,11 @@ It includes the following fields:
 - **Cohort**: Cohort name.
 
 
-## Supplementary Output
+### Supplementary Output
 
 These intermediate files are written alongside the main output. They are not the analysis results themselves but are consumed by downstream tooling — in particular, `oncodrive3d plot` requires all three.
 
-### Processed sequence dataframe
+#### Processed sequence dataframe
 
 TSV file (`<cohort>.seq_df.processed.tsv`) — subset of the built `seq_for_mut_prob.tsv` filtered to genes that entered the run, with the following columns:
 
@@ -229,14 +231,14 @@ TSV file (`<cohort>.seq_df.processed.tsv`) — subset of the built `seq_for_mut_
 - **Tri_context**: per-base trinucleotide contexts along the CDS.
 - **Reference_info**: flag indicating whether the genomic coordinates were resolved against the Proteins API (`1`) or fallback sources. Only `Reference_info == 1` entries can be paired with site-level mutability — see [mutability.md](mutability.md).
 
-### Processed mutations
+#### Processed mutations
 
 TSV file (`<cohort>.mutations.processed.tsv`) — input MAF after Oncodrive3D's parsing pass: filtered to missense variants, protein positions extracted, transcript IDs mapped against the built datasets, and the columns `O3D_transcript_ID` and `Transcript_status` appended (see the `Transcript_status` field documented under [Gene-level output](#gene-level-output) for the possible values).
 
-### Missense probability dictionary
+#### Missense probability dictionary
 
 JSON file (`<cohort>.miss_prob.processed.json`) — dictionary keyed by `{Uniprot_ID}-F{fragment}`, where each value is a per-residue vector of missense-mutation probabilities. The vector is derived from the cohort's mutational profile, or from the site-level mutability table when `--mutability_config_path` is provided.
 
-### Logs
+#### Logs
 
 `log/` subdirectory — log files produced during the run.

--- a/docs/run_input_output.md
+++ b/docs/run_input_output.md
@@ -128,7 +128,7 @@ A small helper script ([tools/preprocessing/get_regions_file.py](../tools/prepro
     ```
     Supported genomes: `hg18`, `hg19`, `hg38`, `mm10`, `mm39`. The first argument is the genome build; the second is the k-mer size (typically `3` for trinucleotide contexts).
 
-# Ouput
+# Output
 
 The `oncodrive3d run command` performs the 3D clustering analysis, generating both main and supplementary output files. The main output files include a gene-level output and a residue-level output, both summarizing the results of the analysis. The supplementary output files include the processed input files and a processed file derived from the Oncodrive3D built datasets, containing information on the genes being analyzed.
 

--- a/docs/run_input_output.md
+++ b/docs/run_input_output.md
@@ -115,46 +115,18 @@ To compute the mutation profile with BGSignature two main files are required:
     
 #### Create the Regions File  
 
-The regions file can be generated using BGReference. Below is an example of a Python script to create a regions file for a specified genome and k-mer size.
+A small helper script ([tools/preprocessing/get_regions_file.py](../tools/preprocessing/get_regions_file.py)) generates the regions file via BGReference.
 
 1. Install BGReference:
     ```
     pip install bgreference
     ```
 
-2. Save the following Python script as get_regions_file.py:
-
-    ```python
-    import sys
-    from bgreference import refseq
-
-    CHR = [str(i) for i in range(1, 20)] + ['X', 'Y', 'M']
-
-
-    def compute_sizes(genome, kmer):
-        sizes = []
-        for chr_ in CHR:
-            seq = refseq(genome, f"chr{chr_}", start=(1 + kmer // 2), size=None)
-            sizes.append(tuple(map(str, (chr_, 1 + kmer // 2, len(seq) - kmer // 2))))
-        return sizes
-
-
-    def write(sizes):
-        print('\t'.join(('CHROMOSOME', 'START', 'END')))
-        for s in sizes:
-            print('\t'.join(s))
-
-    if __name__ == '__main__':
-        genome = sys.argv[1]
-        kmer = int(sys.argv[2])
-        write(compute_sizes(genome, kmer))
+2. Run the helper from the repo root:
     ```
-
-3. Run the script:
-
+    python tools/preprocessing/get_regions_file.py hg38 3 > hg38_wg_regions.tsv
     ```
-    python3 get_regions_file.py hg38 3 > hg38_wg_regions.tsv
-    ```
+    Supported genomes: `hg18`, `hg19`, `hg38`, `mm10`, `mm39`. The first argument is the genome build; the second is the k-mer size (typically `3` for trinucleotide contexts).
 
 # Ouput
 

--- a/docs/run_input_output.md
+++ b/docs/run_input_output.md
@@ -244,3 +244,27 @@ It includes the following fields:
 
 
 ## Supplementary Output
+
+These intermediate files are written alongside the main output. They are not the analysis results themselves but are consumed by downstream tooling — in particular, `oncodrive3d plot` requires all three.
+
+### Processed sequence dataframe
+
+TSV file (`<cohort>.seq_df.processed.tsv`) — subset of the built `seq_for_mut_prob.tsv` filtered to genes that entered the run, with the following columns:
+
+- **Gene**, **HGNC_ID**, **Ens_Gene_ID**, **Ens_Transcr_ID**, **Refseq_prot**, **Uniprot_ID**, **F**: identifier and fragment-number metadata.
+- **Seq**, **Seq_dna**: protein and coding-DNA sequences.
+- **Chr**, **Reverse_strand**, **Exons_coord**: genomic coordinates of the transcript (used by mutability mode).
+- **Tri_context**: per-base trinucleotide contexts along the CDS.
+- **Reference_info**: flag indicating whether the genomic coordinates were resolved against the Proteins API (`1`) or fallback sources. Only `Reference_info == 1` entries can be paired with site-level mutability — see [mutability.md](mutability.md).
+
+### Processed mutations
+
+TSV file (`<cohort>.mutations.processed.tsv`) — input MAF after Oncodrive3D's parsing pass: filtered to missense variants, protein positions extracted, transcript IDs mapped against the built datasets, and the columns `O3D_transcript_ID` and `Transcript_status` appended (see the `Transcript_status` field documented under [Gene-level output](#gene-level-output) for the possible values).
+
+### Missense probability dictionary
+
+JSON file (`<cohort>.miss_prob.processed.json`) — dictionary keyed by `{Uniprot_ID}-F{fragment}`, where each value is a per-residue vector of missense-mutation probabilities. The vector is derived from the cohort's mutational profile, or from the site-level mutability table when `--mutability_config_path` is provided.
+
+### Logs
+
+`log/` subdirectory — log files produced during the run.

--- a/docs/run_input_output.md
+++ b/docs/run_input_output.md
@@ -140,81 +140,78 @@ The `oncodrive3d run command` performs the 3D clustering analysis, generating bo
 
 CSV file (`<cohort>.3d_clustering_genes.csv`) containing the results of the analysis at the gene level. The genes (rows) are sorted by ascending order based on significance and deviation from neutrality. 
 
-It includes the following fields:
+| Field | Description |
+| --- | --- |
+| `Gene` | HUGO symbol or identifier of the gene being analyzed. |
+| `Uniprot_ID` | Identifier for the gene's protein product in the UniProt database. |
+| `pval` | The p-value indicating the statistical significance of the gene in the 3D clustering analysis (lowest p-value among the residues of the gene). |
+| `qval` | Adjusted p-value (q-value) to control for false discovery rate (FDR) using the Benjamini-Hochberg method. |
+| `C_gene` | Binary label indicating if the gene is detected to be significant (by default if `q-value < 0.01`). |
+| `C_pos` | List of protein positions of the gene clusters. |
+| `C_label` | List of labels indicating the clump to which each cluster is grouped. |
+| `Pos_top_vol` | Position of the most significant cluster. |
+| `Score_obs_sim_top_vol` | 3D clustering score of the gene (rescaled 3D clustering score of the residue with the lowest p-value; if multiple residues have the same lowest p-value, the maximum rescaled 3D clustering score among those residues is used). |
+| `Mut_in_gene` | Number of missense mutations in the gene. |
+| `Clust_mut` | Number of missense mutations in significant clusters. |
+| `Clust_res` | Number of residues detected as significant clusters. |
+| `Mut_in_top_vol` | Number of missense mutations in the most significant cluster (in the volume of the residue with the lowest p-value). |
+| `Mut_in_top_cl_vol` | Number of missense mutations in the clusters of the most significant clump (in the volume of residues of the clump that includes the residue with the lowest p-value). |
+| `PAE_top_vol` | Weighted average predicted aligned error (PAE) between the residues in the volume of the most significant cluster. |
+| `pLDDT_top_vol` | Weighted average predicted local distance difference test (pLDDT) between the residues in the volume of the most significant cluster. |
+| `pLDDT_top_cl_vol` | Weighted average pLDDT between the residues in the volume of the most significant clump. |
+| `Ratio_not_in_structure` | Diagnostic field representing the proportion of mutations in the input file that are mapped to positions not covered by the structure. |
+| `Ratio_WT_mismatch` | Diagnostic field representing the proportion of mutations in the input file where the wild-type (WT) amino acid does not match the corresponding residue in the structural model. |
+| `Mut_zero_mut_prob` | Diagnostic field representing the proportion of mutations in the input file that are assigned a mutation probability of zero. This field is relevant only when a mutability configuration file is provided as input (`-m`, `--mutability_config_path`). |
+| `Pos_zero_mut_prob` | Diagnostic field reporting the mutated protein position with assigned a mutation probability of zero. This field is relevant only when a mutability configuration file is provided as input (`-m`, `--mutability_config_path`). |
+| `Cancer` | Cancer type. |
+| `Cohort` | Cohort name. |
+| `F` | Fragment of the AlphaFold predicted structure (1 = no fragmentation, *n*M = merged from *n* fragments). |
+| `Transcript_ID` | Ensembl transcript ID provided in the input file. |
+| `O3D_transcript_ID` | Ensembl transcript ID mapped to the given gene in the Oncodrive3D built datasets. |
+| `Transcript_status` | Transcript mapping status between input data and O3D built datasets. Possible values: `Input_missing` (transcript ID absent from input); `O3D_missing` (transcript ID absent from O3D datasets); `Mismatch` (input and O3D transcript IDs differ); `Match` (IDs agree). |
+| `Status` | Processing status for the 3D clustering analysis. See [possible values](#status-values) below. |
 
-- **Gene**: HUGO symbol or identifier of the gene being analyzed.
-- **Uniprot_ID**: Identifier for the gene's protein product in the UniProt database.
-- **pval**:  The p-value indicating the statistical significance of the gene in the 3D clustering analysis (lowest p-value among the residues of the gene).
-- **qval**: Adjusted p-value (q-value) to control for false discovery rate (FDR) using the Benjamini-Hochberg method.
-- **C_gene**: Binary label indicating if the gene is detected to be significant (by default if `q-value < 0.01`).
-- **C_pos**: List of protein positions of the gene clusters.
-- **C_label**: List of labels indicating the clump to which each cluster is grouped.
-- **Pos_top_vol**: Position of the most significant cluster.
-- **Score_obs_sim_top_vol**: 3D clustering score of the gene (rescaled 3D clustering score of the residue with the lowest p-value; if multiple residues have the same lowest p-value, the maximum rescaled 3D clustering score among those residues is used).
-- **Mut_in_gene**: Number of missense mutations in the gene.
-- **Clust_mut**: Number of missense mutations in significant clusters.
-- **Clust_res**: Number of residues detected as significant clusters.
-- **Mut_in_top_vol**: Number of missense mutations in the most significant cluster (in the volume of the residue with the lowest p-value).
-- **Mut_in_top_cl_vol**: Number of missense mutations in the clusters of the most significant clump (in the volume of residues of the clump that includes the residue with the lowest p-value).
-- **PAE_top_vol**: Weighted average predicted aligned error (PAE) between the residues in the volume of the most significant cluster.
-- **pLDDT_top_vol**: Weighted average predicted local distance difference test (pLDDT) between the residues in the volume of the most significant cluster.
-- **pLDDT_top_cl_vol**: Weighted average pLDDT between the residues in the volume of the most significant clump.
-- **Ratio_not_in_structure**: Diagnostic field rapresenting the proportion of mutations in the input file that are mapped to positions not covered by the structure.
-- **Ratio_WT_mismatch**: Diagnostic field rapresenting the proportion of mutations in the input file where the wild-type (WT) amino acid does not match the corresponding residue in the structural model.
-- **Mut_zero_mut_prob**: Diagnostic field rapresenting the proportion of mutations in the input file that are assigned a mutation probability of zero. This field is relevant only when a mutability configuration file is provided as input (`-m`, `--mutability_config_path`).  
-- **Pos_zero_mut_prob**: Diagnostic field reporting the mutated protein position with assigned a mutation probability of zero. This field is relevant only when a mutability configuration file is provided as input (`-m`, `--mutability_config_path`).  
-- **Cancer**: Cancer type.
-- **Cohort**: Cohort name.
-- **F**: Fragment of the AlphaFold predicted structure (1 = no fragmentation, *n*M = merged from *n* fragments).
-- **Transcript_ID**: Ensembl transcript ID provided in the input file.
-- **O3D_transcript_ID**: Ensembl trasncript ID mapped to the given gene in the Oncodrive3D built datasets.
-- **Transcript_status**: Transcripts mapping status indicating whether the transcript IDs matches between the input data and the Oncodrive3D built datasets. Possible values are:
-    - `Input_missing`: Transcript ID is missing from the input file.
-    - `O3D_missing`: Transcript ID is missing from the Oncodrive3D built datasets.
-    - `Mismatch`: Transcript ID in the input file does not match the transcript ID in the Oncodrive3D built datasets.
-    - `Match`: Transcript ID in the input file matches the transcript ID in the Oncodrive3D built datasets.
-- **Status**: Processing status for 3D clustering analysis. Possible values are:
-    - `Processed`: The gene has been successfully processed, with a 3D clustering score and a p-value assigned.
-    - `No_mut`: The gene contains one or no mutations.
-    - `No_density`: The maximum number of mutations in the spatial volume of any residue is one or less.
-    - `No_ID_mapping`: No corresponding UniProt ID is found for the given gene in the Oncodrive3D built datasets.
-    - `Cmap_not_found`: The contact map for the gene's structural data is not available.
-    - `Mut_not_in_structure`: The proportion of mutations mapped to positions outside the boundaries of the provided PDB structure exceeds the threshold for mapping issues
-    (`--thr_mapping_issue`, default: `0.1`).
-    - `WT_mismatch`: The proportion of mutations in the input file where the wild-type amino acid does not match the corresponding residue in the structural model exceeds the threshold for mapping issues (`--thr_mapping_issue`, default: `0.1`).
-    - `Mut_with_zero_prob`: The proportion of mutations mapped to positions with a mutation probability of zero exceeds the threshold for mapping issues (`--thr_mapping_issue`, default: `0.1`).
-    - `No_mutability`: A mutability configuration file (`-m`, `--mutability_config_path`) was provided, but accurate information on the DNA sequence of the gene is missing in the Oncodrive3D built datasets.
-    - `NA_miss_prob`: The missense probability vector computed for the protein includes NAs values.
-    - `Fragmented`: The protein structure is predicted as fragments by AlphaFold, and the analysis of fragmented structures is not enabled (`-f`, `--no_fragments`).
+##### Status values
 
+- `Processed`: The gene has been successfully processed, with a 3D clustering score and a p-value assigned.
+- `No_mut`: The gene contains one or no mutations.
+- `No_density`: The maximum number of mutations in the spatial volume of any residue is one or less.
+- `No_ID_mapping`: No corresponding UniProt ID is found for the given gene in the Oncodrive3D built datasets.
+- `Cmap_not_found`: The contact map for the gene's structural data is not available.
+- `Mut_not_in_structure`: The proportion of mutations mapped to positions outside the boundaries of the provided PDB structure exceeds the threshold for mapping issues (`--thr_mapping_issue`, default: `0.1`).
+- `WT_mismatch`: The proportion of mutations in the input file where the wild-type amino acid does not match the corresponding residue in the structural model exceeds the threshold for mapping issues (`--thr_mapping_issue`, default: `0.1`).
+- `Mut_with_zero_prob`: The proportion of mutations mapped to positions with a mutation probability of zero exceeds the threshold for mapping issues (`--thr_mapping_issue`, default: `0.1`).
+- `No_mutability`: A mutability configuration file (`-m`, `--mutability_config_path`) was provided, but accurate information on the DNA sequence of the gene is missing in the Oncodrive3D built datasets.
+- `NA_miss_prob`: The missense probability vector computed for the protein includes NAs values.
+- `Fragmented`: The protein structure is predicted as fragments by AlphaFold, and the analysis of fragmented structures is not enabled (`-f`, `--no_fragments`).
 
 #### Residue-level output
   
 CSV file (`<cohort>.3d_clustering_pos.csv`) containing the results of the analysis at the level of mutated residues. Each row corresponds to a mutated position within a gene and includes detailed information for each potential mutational cluster.
 
-It includes the following fields:
-
-- **Gene**: HUGO symbol or identifier of the gene being analyzed.
-- **Uniprot_ID**: Identifier for the gene's protein product in the UniProt database.
-- **Pos**: Protein position.
-- **Mut_in_gene**: Number of missense mutations in the gene.
-- **Mut_in_res**: Number of missense mutations in the residue.
-- **Mut_in_vol**: Number of missense mutations in the volume of the residue.
-- **Score**: 3D clustering score for the residue.
-- **Score_obs_sim**: Rescaled 3D clustering score for the residue.
-- **pval**: The p-value of the residue in the 3D clustering analysis.
-- **C**: Binary label indicating whether the cluster at that residue is significant (1) or not (0). A cluster is marked as significant either because it meets the significance criteria directly or because it has been rescued by contributing mutations to another significant cluster.
-- **C_ext**: Binary label indicating whether the cluster has been rescued by contributing mutations to another significant cluster (1) or if it was significant on its own (0).
-- **Clump**: Identifier for the clump to which the cluster at that residue has been assigned.
-- **Rank**: Rank used to perform the calculation of the 3D clustering score and p-values. 
-- **Mut_in_cl_vol**: Number of missense mutations in the clusters of the clump to which the cluster has been assigned.
-- **Res_in_cl**: Positions of the clusters of the clump to which the cluster has been assigned.
-- **PAE_vol**: Weighted average predicted aligned error (PAE) of the residues in the volume of the cluster.
-- **pLDDT_res**: Predicted local distance difference test (pLDDT) of the residue.
-- **pLDDT_vol**: Weighted average pLDDT between the residues in the volume.
-- **pLDDT_cl_vol**: pLDDT between the residues in the volume of the most significant cluster.
-- **Cancer**: Cancer type.
-- **Cohort**: Cohort name.
+| Field | Description |
+| --- | --- |
+| `Gene` | HUGO symbol or identifier of the gene being analyzed. |
+| `Uniprot_ID` | Identifier for the gene's protein product in the UniProt database. |
+| `Pos` | Protein position. |
+| `Mut_in_gene` | Number of missense mutations in the gene. |
+| `Mut_in_res` | Number of missense mutations in the residue. |
+| `Mut_in_vol` | Number of missense mutations in the volume of the residue. |
+| `Score` | 3D clustering score for the residue. |
+| `Score_obs_sim` | Rescaled 3D clustering score for the residue. |
+| `pval` | The p-value of the residue in the 3D clustering analysis. |
+| `C` | Binary label indicating whether the cluster at that residue is significant (1) or not (0). A cluster is marked as significant either because it meets the significance criteria directly or because it has been rescued by contributing mutations to another significant cluster. |
+| `C_ext` | Binary label indicating whether the cluster has been rescued by contributing mutations to another significant cluster (1) or if it was significant on its own (0). |
+| `Clump` | Identifier for the clump to which the cluster at that residue has been assigned. |
+| `Rank` | Rank used to perform the calculation of the 3D clustering score and p-values. |
+| `Mut_in_cl_vol` | Number of missense mutations in the clusters of the clump to which the cluster has been assigned. |
+| `Res_in_cl` | Positions of the clusters of the clump to which the cluster has been assigned. |
+| `PAE_vol` | Weighted average predicted aligned error (PAE) of the residues in the volume of the cluster. |
+| `pLDDT_res` | Predicted local distance difference test (pLDDT) of the residue. |
+| `pLDDT_vol` | Weighted average pLDDT between the residues in the volume. |
+| `pLDDT_cl_vol` | pLDDT between the residues in the volume of the most significant cluster. |
+| `Cancer` | Cancer type. |
+| `Cohort` | Cohort name. |
 
 
 ### Supplementary Output

--- a/oncodrive3d_pipeline/README.md
+++ b/oncodrive3d_pipeline/README.md
@@ -55,52 +55,25 @@ If you prefer to use Conda, replace `container` in the `-profile` argument with 
 
 ---
 
-```
+```text
 Usage: nextflow run main.nf [OPTIONS]
 
-Example of run using VEP output as input and MANE Select transcripts:
+Example using VEP input and MANE Select transcripts:
   nextflow run main.nf -profile container --data_dir <build_folder> --indir <input> \
                        --vep_input true --mane true
-  
-Options:
-  --indir PATH                    Path to the input directory including the subdirectories 
-                                  `maf` or `vep` and `mut_profile`. 
-  --outdir PATH                   Base output directory.
-                                  Default: ./
-  --outsubdir PATH                Subdirectory created under --outdir.
-                                  Default: run_<timestamp>/
-  --cohort_pattern STR            Pattern expression to filter specific files within the 
-                                  input directory (e.g., 'TCGA*' select only TCGA cohorts). 
-                                  Default: *
-  --data_dir PATH                 Path to the Oncodrive3D datasets directory, which includes 
-                                  the files compiled during the building datasets step.
-                                  Default: ${baseDir}/../datasets/
-  --annotations_dir PATH          Path to the Oncodrive3D annotations directory (required when --plot true).
-                                  Default: ${baseDir}/../annotations/
-  --max_running INT               Maximum number of cohorts to process in parallel.
-                                  Default: 5
-  --cores INT                     Number of CPU cores used to process each cohort. 
-                                  Default: 10
-  --memory STR                    Amount of memory allocated for processing each cohort. 
-                                  Default: 70GB
-  --vep_input BOOLEAN             Use `vep/` subdir as input and select transcripts matching 
-                                  the Ensembl transcript IDs in Oncodrive3D built datasets. 
-                                  Default: false
-  --mane                          Prioritize structures corresponding to MANE transcripts if 
-                                  multiple structures are associated to the same gene.
-                                  Default: false
-  --ignore_mapping_issues         Disable filtering mismatching mutations by setting
-                                  `--thr_mapping_issue 1` in the underlying `oncodrive3d run`.
-                                  Default: false
-  --verbose                       Enable verbose logging for underlying Oncodrive3D commands.
-                                  Default: false
-  --seed INT                      Seed value for reproducibility.
-                                  Default: 128
-  --plot BOOL                     Generate summary/gene plots (requires annotations_dir).
-                                  Default: false
-  --chimerax_plot BOOL            Generate ChimeraX snapshots.
-                                  Default: false
 ```
+
+Commonly tweaked options:
+
+- `--indir <path>` — input directory with `maf/` (or `vep/`) and `mut_profile/` subdirs.
+- `--data_dir <path>` — Oncodrive3D datasets built by `oncodrive3d build-datasets`.
+- `--annotations_dir <path>` — annotation bundle (required when `--plot true`).
+- `--vep_input true` — read inputs from `vep/` instead of `maf/`.
+- `--mane true` — prioritize MANE Select transcripts when multiple structures match a gene.
+- `--plot true` / `--chimerax_plot true` — enable the plotting modules (see [Optional modules](#optional-modules) below).
+- `--max_running <int>` — number of cohorts processed in parallel (default `5`).
+
+See [`nextflow.config`](nextflow.config) for the full parameter list and defaults.
 
 ### Optional modules
 

--- a/oncodrive3d_pipeline/README.md
+++ b/oncodrive3d_pipeline/README.md
@@ -71,6 +71,7 @@ Commonly tweaked options:
 - `--vep_input true` — read inputs from `vep/` instead of `maf/`.
 - `--mane true` — prioritize MANE Select transcripts when multiple structures match a gene.
 - `--plot true` / `--chimerax_plot true` — enable the plotting modules (see [Optional modules](#optional-modules) below).
+- `--ignore_mapping_issues true` — disable filtering of mismatched mutations (sets `--thr_mapping_issue 1` in the underlying `oncodrive3d run`).
 - `--max_running <int>` — number of cohorts processed in parallel (default `5`).
 
 See [`nextflow.config`](nextflow.config) for the full parameter list and defaults.

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -505,7 +505,7 @@ def plot(gene_result_path,
 @click.option("--fragmented_proteins", help="Include fragmented proteins", is_flag=True)
 @click.option("--transparent_bg", help="Set background as transparent", type=str, is_flag=True)
 @click.option("--chimerax_bin", help="Path to chimerax installation", type=str, default="/usr/bin/chimerax")
-@click.option("--af_version", type=click.IntRange(min=1, clamp=False), default=4,
+@click.option("--af_version", type=click.IntRange(min=1, clamp=False), default=6,
               help="Version of AlphaFold 2 predictions used for structures")
 @click.option("-v", "--verbose", help="Verbose", is_flag=True)
 @setup_logging_decorator

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -503,7 +503,7 @@ def plot(gene_result_path,
 @click.option("--pixel_size", help="Pixel size (smaller value is larger number of pixels)", type=float, default=0.08)
 @click.option("--cluster_ext", help="Include extended clusters", is_flag=True)
 @click.option("--fragmented_proteins", help="Include fragmented proteins", is_flag=True)
-@click.option("--transparent_bg", help="Set background as transparent", type=str, is_flag=True)
+@click.option("--transparent_bg", help="Set background as transparent", is_flag=True)
 @click.option("--chimerax_bin", help="Path to chimerax installation", type=str, default="/usr/bin/chimerax")
 @click.option("--af_version", type=click.IntRange(min=1, clamp=False), default=6,
               help="Version of AlphaFold 2 predictions used for structures")

--- a/tools/preprocessing/get_regions_file.py
+++ b/tools/preprocessing/get_regions_file.py
@@ -1,0 +1,34 @@
+import sys
+
+from bgreference import refseq
+
+
+GENOME_AUTOSOMES = {
+    "hg18": 22, "hg19": 22, "hg38": 22,
+    "mm10": 19, "mm39": 19,
+}
+
+
+def compute_sizes(genome, kmer):
+    if genome not in GENOME_AUTOSOMES:
+        raise ValueError(
+            f"Unsupported genome: {genome!r}. Supported: {sorted(GENOME_AUTOSOMES)}"
+        )
+    chroms = [str(i) for i in range(1, GENOME_AUTOSOMES[genome] + 1)] + ['X', 'Y']
+    sizes = []
+    for chr_ in chroms:
+        seq = refseq(genome, chr_, start=(1 + kmer // 2), size=None)
+        sizes.append(tuple(map(str, (chr_, 1 + kmer // 2, len(seq) - kmer // 2))))
+    return sizes
+
+
+def write(sizes):
+    print('\t'.join(('CHROMOSOME', 'START', 'END')))
+    for s in sizes:
+        print('\t'.join(s))
+
+
+if __name__ == '__main__':
+    genome = sys.argv[1]
+    kmer = int(sys.argv[2])
+    write(compute_sizes(genome, kmer))


### PR DESCRIPTION
## Summary
Documentation cleanup pass focused on cutting duplication with `--help` output and across files.

## Changes
- **`README.md`**:
  - Replaced verbose `--help`-style option tables for `build-datasets` and `run` with example blocks and a `oncodrive3d <cmd> --help` pointer.
  - Added `mouse` example to the `build-datasets` block.
  - Collapsed the MANE preprocessing TIP and the Parallel Processing section to one-line pointers to their dedicated docs.
  - Trimmed verbose WARNING/NOTE/Requirements blocks; converted absolute GitHub URLs to relative paths; minor capitalization and blank-line cleanup.
- **`docs/annotations_plotting.md`**:
  - Replaced "Key options" bullet lists for `build-annotations`, `plot`, and `chimerax-plot` with `--help` pointers plus a tight "Worth knowing" callout that keeps only the non-obvious context (mouse ΔΔG story, `--ddg_mismatch_threshold` semantics, matching-input warnings, etc.).
  - Tightened the dense ΔΔG step in "What happens internally".
  - Added the three-variant `build-annotations` example (default / MANE-built dataset / mouse with custom ΔΔG).](docs: tighten references; align chimerax-plot defaults)