### PR TITLE
parallelize PDB_Tool execution in build-annotations

### DIFF
--- a/scripts/plotting/build_annotations.py
+++ b/scripts/plotting/build_annotations.py
@@ -75,13 +75,12 @@ def get_annotations(data_dir,
     else:
         logger.warning(f"Currently, stability change annotation is not available for {species} but only for Homo sapiens: Skipping...")
     
-    ## TODO: Enable multiprocessing for PDB_Tool
     ## TODO: Evaluate the possibility of installing PDB_Tool instead of using container
-    
+
     # Run PDB_Tool
     logger.info("Extracting pACC and 2° structure..")
     path_pdb_structure = os.path.join(data_dir, "pdb_structures")
-    pdb_tool_output = run_pdb_tool(input_dir=path_pdb_structure, output_dir=output_dir)
+    pdb_tool_output = run_pdb_tool(input_dir=path_pdb_structure, output_dir=output_dir, cores=cores)
     logger.info("Extraction completed!")
     
     # Parse PDB_Tool

--- a/scripts/plotting/pdb_tool.py
+++ b/scripts/plotting/pdb_tool.py
@@ -37,8 +37,18 @@ def decompress_pdb_gz(input_dir):
     
 
 def _run_pdb_tool_one(input_path, output_path, f):
-    """Invoke the PDB_Tool binary on a single structure."""
-    subprocess.run(["PDB_Tool", "-i", input_path, "-o", output_path, "-F", f])
+    """Invoke the PDB_Tool binary on a single structure. Captures stderr so failures
+    surface as warnings instead of garbling the tqdm bar."""
+    result = subprocess.run(
+        ["PDB_Tool", "-i", input_path, "-o", output_path, "-F", f],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        logger.warning(
+            f"PDB_Tool failed on {os.path.basename(input_path)} "
+            f"(rc={result.returncode}): {result.stderr.strip()}"
+        )
 
 
 def run_pdb_tool(input_dir, output_dir, f="4", cores=1):
@@ -56,9 +66,12 @@ def run_pdb_tool(input_dir, output_dir, f="4", cores=1):
 
     decompress_pdb_gz(input_dir)
     pdb_files = [file for file in os.listdir(input_dir) if file.endswith(".pdb")]
-    logger.debug(f"Running PDB_Tool with {cores} worker(s)...")
+    if not pdb_files:
+        return pdb_tool_output
 
-    max_workers = max(1, int(cores))
+    max_workers = max(1, min(cores, len(pdb_files)))
+    logger.debug(f"Running PDB_Tool with {max_workers} worker(s)...")
+
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
         futures = [
             executor.submit(

--- a/scripts/plotting/pdb_tool.py
+++ b/scripts/plotting/pdb_tool.py
@@ -3,6 +3,7 @@ import logging
 import subprocess
 import re
 import shutil
+from concurrent.futures import ThreadPoolExecutor, as_completed
 
 import numpy as np
 import pandas as pd
@@ -35,26 +36,42 @@ def decompress_pdb_gz(input_dir):
         logger.debug("Decompression complete!")
     
 
-def run_pdb_tool(input_dir, output_dir, f="4"):
+def _run_pdb_tool_one(input_path, output_path, f):
+    """Invoke the PDB_Tool binary on a single structure."""
+    subprocess.run(["PDB_Tool", "-i", input_path, "-o", output_path, "-F", f])
+
+
+def run_pdb_tool(input_dir, output_dir, f="4", cores=1):
     """
     Use PDB_Tool to extract features from all pdb files in directory.
+
+    Each invocation is independent, so the calls are dispatched across a thread
+    pool. PDB_Tool runs as a subprocess, so the GIL doesn't constrain throughput.
     """
 
     pdb_tool_output = os.path.join(output_dir, "pdb_tool")
     if not os.path.isdir(pdb_tool_output):
         os.makedirs(pdb_tool_output)
         logger.debug(f'mkdir {pdb_tool_output}')
-    
+
     decompress_pdb_gz(input_dir)
-    pdb_files = [file for file in os.listdir(input_dir) if file.endswith(".pdb")]    
-    logger.debug("Running PDB_Tool...")
-    for file in tqdm(pdb_files, desc="Running PDB_Tool"):
-        output = os.path.join(pdb_tool_output, file.replace(".pdb", ".feature"))
-        # Singularity container
-        #subprocess.run(["singularity", "exec", f"{pdb_tool_sif_path}", "/PDB_Tool/PDB_Tool", "-i", f"{input_dir}/{file}", "-o", output, "-F", f])            
-        # Added to $PATH
-        subprocess.run(["PDB_Tool", "-i", os.path.join(input_dir, file), "-o", output, "-F", f])   
-        
+    pdb_files = [file for file in os.listdir(input_dir) if file.endswith(".pdb")]
+    logger.debug(f"Running PDB_Tool with {cores} worker(s)...")
+
+    max_workers = max(1, int(cores))
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        futures = [
+            executor.submit(
+                _run_pdb_tool_one,
+                os.path.join(input_dir, file),
+                os.path.join(pdb_tool_output, file.replace(".pdb", ".feature")),
+                f,
+            )
+            for file in pdb_files
+        ]
+        for future in tqdm(as_completed(futures), total=len(futures), desc="Running PDB_Tool"):
+            future.result()
+
     return pdb_tool_output
             
             


### PR DESCRIPTION
## Summary
- Dispatch PDB_Tool subprocess calls through `concurrent.futures.ThreadPoolExecutor` instead of a serial for-loop. ThreadPool is the right tool here since the work is in a child process — Python's GIL doesn't bind us, and we avoid pickle/fork overhead of `multiprocessing.Pool`.
- Plumb the existing `cores` parameter from `get_annotations` through to `run_pdb_tool` (previously had no concurrency knob). `cores=1` default means callers that don't pass it preserve the prior serial behavior — drop-in change.
- Capture PDB_Tool stdout/stderr per call and log a warning on non-zero exit, so failures surface in the log (previously silently swallowed) and stderr no longer garbles the tqdm bar.
- tqdm progress bar preserved via `as_completed(futures)` — same look, advances on each completion.