### PR TITLE
fix: silence pandas regex FutureWarning in uniprot_feat

### DIFF
--- a/scripts/plotting/uniprot_feat.py
+++ b/scripts/plotting/uniprot_feat.py
@@ -230,8 +230,8 @@ def parse_prot_feat(feat_df):
     # Domain
     feat_df.loc[feat_df["Type"] == "DOMAIN", "Description"] = feat_df[feat_df["Type"] == "DOMAIN"].apply(
         lambda x: x["Description"].split(";")[0] if pd.notna(x["Description"]) else np.nan, axis=1)
-    feat_df.loc[feat_df["Type"] == "DOMAIN", "Description"] = feat_df.loc[feat_df["Type"] == "DOMAIN", 
-                                                                          "Description"].str.replace(r' \d+', '')
+    feat_df.loc[feat_df["Type"] == "DOMAIN", "Description"] = feat_df.loc[feat_df["Type"] == "DOMAIN",
+                                                                          "Description"].str.replace(r' \d+', '', regex=True)
     feat_df["Domain_ID"] = feat_df.pop("Domain_ID")
     
     return feat_df


### PR DESCRIPTION
pandas is deprecating implicit regex detection in `Series.str.replace`. The pattern `r' \d+'` is a regex (strips trailing numbers from DOMAIN descriptions, e.g. "Kinase 1" → "Kinase"). Adding `regex=True` keeps current behavior and silences the FutureWarning.
