### PR TITLE
fix: handle infinite values in anomaly score calculation

### DIFF
--- a/scripts/run/score_and_simulations.py
+++ b/scripts/run/score_and_simulations.py
@@ -77,6 +77,8 @@ def get_dcm_anomaly_score(k, n, p, decimal=600):
     num = dcm_binom_logsf(k-1, n, p)
     den = stats.binom.logpmf(k=n, n=n, p=p)
 
+    if isinstance(num, float) and np.isinf(num):
+        return np.inf
     return float(num / Decimal(den))
 
 


### PR DESCRIPTION
When an extreme density of mutations is observed on a residue, the probability of seeing it by chance is so small that it gets approximated to zero, and the clustering score becomes infinite. When this happens, Oncodrive3D tries to recompute the score using the `decimal` package (`get_dcm_anomaly_score`), which supports 600-digit precision.

In the reported case, the signal was so high that even 600-digit precision wasn't enough and it hit the precision limit again. This case wasn't expected: `dcm_binom_logsf` returned `np.inf` (a float) instead of a `Decimal`, and the next line tried `float / Decimal` which crashed with a `TypeError`.

closes #87 

## Fix

Check if the high-precision result is again `inf`. In that case, just return `inf` as the clustering score. Nothing changes at the level of p-value calculation.

## Tests

- [x] Re-run the failing cohort and confirm it completes without the `TypeError`
- [x] Check that failing gene appears in the gene-level output with `Status = Processed` and a significant p-value