### PR TITLE
feat: ship three Docker image variants (light, chimerax, full)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -193,3 +193,6 @@ run_*
 # VSC
 launch.json
 .vscode
+
+# Docker build artifacts (ChimeraX installer staged into context)
+chimerax*.deb

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,38 +1,80 @@
+# Multi-target Dockerfile for Oncodrive3D.
+#
+# Targets (each builds on the previous; pick with `--target`):
+#   light    (default)  - oncodrive3d only.
+#                         Covers `run` and `plot` (including normal-tissue
+#                         mutability runs). No external prerequisites to build.
+#   chimerax            - light + ChimeraX. Adds `chimerax-plot`. Requires the
+#                         ChimeraX installer staged in the build context as
+#                         `chimerax.deb` (override via --build-arg CHIMERAX_DEB=).
+#   full                - chimerax + bgdata caches (hg38, mm39) + PDB_Tool.
+#                         Adds `build-datasets` and `build-annotations`.
+#
+# Examples:
+#   docker build --target light    -t oncodrive3d:1.0.9         -t oncodrive3d:latest   .
+#   docker build --target chimerax -t oncodrive3d:1.0.9-chimerax -t oncodrive3d:chimerax .
+#   docker build --target full     -t oncodrive3d:1.0.9-full     -t oncodrive3d:full     .
+
+# Stage 1: build the oncodrive3d wheel
 FROM ghcr.io/astral-sh/uv:0.5-python3.10-bookworm AS build-stage
 
-# Set environment variables
-ENV UV_COMPILE_BYTECODE=1 \
-    BBGLAB_HOME="/home/user/.config/bbglab/"
+ENV UV_COMPILE_BYTECODE=1
 
-# Set the working directory to /oncodrive3d
 WORKDIR /oncodrive3d
 
-# Stage necessary files into the container
 COPY uv.lock uv.lock
 COPY pyproject.toml pyproject.toml
 COPY scripts scripts
 COPY README.md README.md
 
-# Install dependencies and build the project
 RUN mkdir -p /root/.cache/uv \
     && uv sync --frozen --no-dev \
     && uv build
 
-# Second stage: Runtime image
-FROM python:3.10.18-bookworm AS runtime-stage
+# Stage 2: compile PDB_Tool from source (only consumed by the `full` target)
+FROM python:3.10-bullseye AS pdb-tool-stage
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential ca-certificates git \
+    && git clone --depth 1 https://github.com/realbigws/PDB_Tool.git /pdb-tool \
+    && make -C /pdb-tool/source_code \
+    && rm -rf /var/lib/apt/lists/*
 
-# Set environment variables
+# Stage 3 (target=light): just oncodrive3d. No ChimeraX, no PDB_Tool, no bgdata.
+# Debian 11 base keeps layers shareable with the downstream targets that need
+# libssl1.1 + libffi7 for the Ubuntu 20.04 ChimeraX .deb.
+FROM python:3.10-bullseye AS light
+
+COPY --from=build-stage /oncodrive3d/dist /oncodrive3d/dist
+WORKDIR /oncodrive3d
+RUN pip install --no-cache-dir dist/*.tar.gz
+
+LABEL Author="stefano.pellegrini@irbbarcelona.org"
+
+CMD ["oncodrive3D"]
+
+# Stage 4 (target=chimerax): light + ChimeraX
+FROM light AS chimerax
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+ARG CHIMERAX_DEB=chimerax.deb
+COPY ${CHIMERAX_DEB} /tmp/chimerax.deb
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends /tmp/chimerax.deb \
+    && rm /tmp/chimerax.deb \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Stage 5 (target=full): chimerax + bgdata caches (hg38, mm39) + PDB_Tool
+FROM chimerax AS full
+
 ENV BGDATA_LOCAL="/bgdatacache" \
     BBGLAB_HOME="/home/user/.config/bbglab/"
 
-# Copy oncodrive3d from the build stage
-COPY --from=build-stage /oncodrive3d/dist /oncodrive3d/dist
-WORKDIR /oncodrive3d
+# PDB_Tool binary (for `build-annotations`)
+COPY --from=pdb-tool-stage /pdb-tool/PDB_Tool /usr/local/bin/PDB_Tool
 
-# Install oncodrive3d
-RUN pip install dist/*.tar.gz
-
-# Create required directories
 RUN install -d -m 0755 "$BGDATA_LOCAL" "$BBGLAB_HOME"
 
 # Write bgdata configuration
@@ -51,17 +93,14 @@ remote_repository = \"https://bbglab.irbbarcelona.org/bgdata\"\n\
 # Cache repositories\n\
 [cache_repositories]" > "$BBGLAB_HOME/bgdatav2.conf"
 
-# Pre-fetch and prepare genome data
-RUN apt-get update && apt-get install -y curl \
-    && pip install bgdata bgreference \
+# Pre-fetch and prepare genome data (needed by `build-datasets`)
+RUN apt-get update && apt-get install -y --no-install-recommends curl \
+    && pip install --no-cache-dir bgdata bgreference \
     && bgdata get datasets/genomereference/hg38 \
     && bgdata get datasets/genomereference/mm39 \
     && python3 -c "from bgreference import hg38; hg38(1, 1300000, 3000)" \
     && python3 -c "from bgreference import mm39; mm39(1, 1300000, 3000)" \
+    && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-# Set permissions for cache directory
 RUN chmod -R 0755 "$BGDATA_LOCAL"
-
-# Set entrypoint (optional)
-CMD ["python3"]

--- a/README.md
+++ b/README.md
@@ -175,6 +175,9 @@ singularity exec oncodrive3d.sif oncodrive3d run \
     -i <input_maf> -p <mut_profile> -d <build_folder> -C <cohort_name>
 ```
 
+> [!NOTE]
+> Singularity only auto-binds `$HOME` and `$PWD`. If any input or output path lives outside those (e.g. `/data/...` on a cluster), bind that host path explicitly with `-B /path:/path` (e.g. `singularity exec -B /data:/data oncodrive3d.sif ...`).
+
 ### Testing
 
 To verify that Oncodrive3D is installed and configured correctly, you can perform a test run using the provided test input files:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Oncodrive3D
 
-**Oncodrive3D** is a fast and accurate computational method designed to analyze patterns of somatic mutation across tumors, with the goal of identifying **three-dimensional (3D) clusters** of missense mutations and detecting genes under **positive selection**. 
+**Oncodrive3D** is a fast and accurate computational method designed to analyze patterns of somatic mutation across tumors, with the goal of identifying **three-dimensional (3D) clusters** of missense mutations and detecting genes under **positive selection**.
 
 The method leverages **AlphaFold 2-predicted protein structures** and Predicted Aligned Error (PAE) to define residue contacts within the protein's 3D space. When available, it integrates **mutational profiles** to build an accurate background model of neutral mutagenesis. By applying a novel **rank-based statistical approach**, Oncodrive3D scores potential 3D clusters and computes empirical p-values.
 
@@ -60,8 +60,12 @@ This step builds the datasets necessary for Oncodrive3D to run the 3D clustering
 > [!WARNING]
 > This step is time- and resource-intensive: it downloads and processes large amounts of structural data. Ensure adequate disk space, CPU, and a reliable internet connection (AlphaFold, Ensembl, Pfam, and other resources are fetched on demand).
 
+<!-- -->
+
 > [!WARNING]
 > MANE builds force AlphaFold DB v4 structures (non-MANE builds default to v6). PAE files for v4 are no longer hosted after 2025, so MANE builds without `--custom_pae_dir` fall back to binary contact maps. To keep PAE-weighted probability maps, supply precomputed v4 PAE files via `--custom_pae_dir`.
+
+<!-- -->
 
 > [!NOTE]
 > The first time that you run Oncodrive3D building dataset step with a given reference genome, it will download it from our servers. By default the downloaded datasets go to `~/.bgdata`. If you want to move these datasets to another folder you have to define the system environment variable `BGDATA_LOCAL` with an export command.
@@ -94,14 +98,16 @@ See the [Input and Output Documentation](docs/run_input_output.md) for details o
 ### Input
 
 - **Mutations file** (`required`): It can be either:
-   - **<input_maf>**: A Mutation Annotation Format (MAF) file annotated with consequences (e.g., by using [Ensembl Variant Effect Predictor (VEP)](https://www.ensembl.org/info/docs/tools/vep/index.html)).
-   - **<input_vep>**: The unfiltered output of VEP including annotations for all possible transcripts.
+  - **<input_maf>**: A Mutation Annotation Format (MAF) file annotated with consequences (e.g., by using [Ensembl Variant Effect Predictor (VEP)](https://www.ensembl.org/info/docs/tools/vep/index.html)).
+  - **<input_vep>**: The unfiltered output of VEP including annotations for all possible transcripts.
 
 - **<mut_profile>** (`optional`): Dictionary including the normalized frequencies of mutations (*values*) in every possible trinucleotide context (*keys*), such as 'ACA>A', 'ACC>A', and so on.
 
-> [!NOTE] 
+> [!NOTE]
 > Examples of the input files are available in the [Test Input Folder](test/input).  
 Please refer to these examples to understand the expected format and structure of the input files.
+
+<!-- -->
 
 > [!NOTE]
 > Oncodrive3D uses the mutational profile of the cohort to build an accurate background model. However, it’s not strictly required. If the mutational profile is not provided, the tool will use a simple uniform distribution as the background model for simulating mutations and scoring potential 3D clusters.
@@ -130,6 +136,8 @@ See `oncodrive3d run --help` for all options.
 
 > [!WARNING]
 > Human datasets built with the default settings pin canonical transcript metadata to the January 2024 Ensembl archive (release 111 / GENCODE v45). Annotate input variants with the same Ensembl/GENCODE release to avoid transcript-ID mismatches.
+
+<!-- -->
 
 > [!TIP]
 > To maximize the number of matching transcripts between your input mutations and Oncodrive3D's structures, supply the unfiltered VEP output as input along with `--o3d_transcripts --use_input_symbols`.
@@ -171,11 +179,11 @@ singularity exec oncodrive3d.sif oncodrive3d run \
 
 ### Testing
 
-To verify that Oncodrive3D is installed and configured correctly, you can perform a test run using the provided test input files: 
+To verify that Oncodrive3D is installed and configured correctly, you can perform a test run using the provided test input files:
 
-```
+```bash
 oncodrive3d run -d <build_folder> \
-                -i ./test/input/maf/TCGA_WXS_ACC.in.maf \ 
+                -i ./test/input/maf/TCGA_WXS_ACC.in.maf \
                 -p ./test/input/mut_profile/TCGA_WXS_ACC.sig.json \
                 -o ./test/output/ -C TCGA_WXS_ACC
 ```
@@ -196,6 +204,23 @@ Oncodrive3D ships with a [Nextflow](https://www.nextflow.io/) pipeline for runni
 
 Oncodrive3D is available to the general public subject to certain conditions described in its [LICENSE](LICENSE).
 
+## Credits
+
+Oncodrive3D was originally written by Stefano Pellegrini.
+
+We thank the following people for their assistance in the development of this tool:
+
+- [@koszulordie](https://github.com/koszulordie)
+- [@FedericaBrando](https://github.com/FedericaBrando)
+- [@FerriolCalvet](https://github.com/FerriolCalvet)
+- [@odove](https://github.com/odove)
+
 ## Citation
 
-If you use Oncodrive3D in your research, please cite the original paper: [Oncodrive3D: fast and accurate detection of structural clusters of somatic mutations under positive selection](https://academic.oup.com/nar/article/53/15/gkaf776/8234003).
+If you use Oncodrive3D in your research, please cite:
+
+> **Oncodrive3D: fast and accurate detection of structural clusters of somatic mutations under positive selection**
+>
+> Stefano Pellegrini, Olivia Dove-Estrella, Ferran Muiños, Nuria Lopez-Bigas, Abel Gonzalez-Perez
+>
+> *Nucleic Acids Research* 53(15) (2025) doi:[10.1093/nar/gkaf776](https://doi.org/10.1093/nar/gkaf776)

--- a/README.md
+++ b/README.md
@@ -158,8 +158,6 @@ Oncodrive3D ships three image variants, each layered on top of the previous so y
 | ChimeraX | `bbglab/oncodrive3d:chimerax`, `:<version>-chimerax` | ~4.3 GB | `run`, `plot`, `chimerax-plot` |
 | Full | `bbglab/oncodrive3d:full`, `:<version>-full` | ~16 GB | `run`, `plot`, `chimerax-plot`, `build-datasets`, `build-annotations` |
 
-Pick **light** for cohort runs (including mutability-aware normal-tissue runs) and standard plotting. Pick **chimerax** if you also need `chimerax-plot`. Pick **full** if you also need to build datasets or annotations from scratch.
-
 #### Docker
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Please refer to these examples to understand the expected format and structure o
 
 ### Main Output
 
-- **Gene-level output**: CSV file (`\<cohort>.3d_clustering_genes.csv`) containing the results of the analysis at the gene level. Each row represents a gene, sorted from the most significant to the least significant based on the 3D clustering analysis. The table also includes genes that were not analyzed, with the reason for exclusion provided in the `status` column.
+- **Gene-level output**: CSV file (`<cohort>.3d_clustering_genes.csv`) containing the results of the analysis at the gene level. Each row represents a gene, sorted from the most significant to the least significant based on the 3D clustering analysis. The table also includes genes that were not analyzed, with the reason for exclusion provided in the `status` column.
   
 - **Residue-level output**: CSV file (`<cohort>.3d_clustering_pos.csv`) containing the results of the analysis at the level of mutated residues. Each row corresponds to a mutated position within a gene and includes detailed information for each potential mutational cluster.
 

--- a/README.md
+++ b/README.md
@@ -140,12 +140,33 @@ Oncodrive3D can ingest **site-specific mutability tables** when a single mutatio
 
 Please see the [Mutability-aware runs guide](docs/mutability.md) for the expected file formats, config schema, and troubleshooting tips.
 
-### Running With Singularity
+### Container Images
 
+Oncodrive3D ships three image variants, each layered on top of the previous so you can pick the smallest one that covers your workflow:
+
+| Variant | Tags | Approx size | Supported commands |
+| --- | --- | --- | --- |
+| Light | `bbglab/oncodrive3d:latest`, `:light`, `:<version>`, `:<version>-light` | ~1.5 GB | `run`, `plot` |
+| ChimeraX | `bbglab/oncodrive3d:chimerax`, `:<version>-chimerax` | ~4.3 GB | `run`, `plot`, `chimerax-plot` |
+| Full | `bbglab/oncodrive3d:full`, `:<version>-full` | ~16 GB | `run`, `plot`, `chimerax-plot`, `build-datasets`, `build-annotations` |
+
+Pick **light** for cohort runs (including mutability-aware normal-tissue runs) and standard plotting. Pick **chimerax** if you also need `chimerax-plot`. Pick **full** if you also need to build datasets or annotations from scratch.
+
+#### Docker
+
+```bash
+docker pull bbglab/oncodrive3d:latest
+docker run --rm -v "$PWD":/data bbglab/oncodrive3d:latest \
+    oncodrive3d run -i /data/<input_maf> -p /data/<mut_profile> \
+                    -d /data/<build_folder> -C <cohort_name> -o /data/<output_dir>
 ```
+
+#### Singularity
+
+```bash
 singularity pull oncodrive3d.sif docker://bbglab/oncodrive3d:latest
-singularity exec oncodrive3d.sif oncodrive3d run -i <input_maf> -p <mut_profile> \ 
-                                                 -d <build_folder> -C <cohort_name>
+singularity exec oncodrive3d.sif oncodrive3d run \
+    -i <input_maf> -p <mut_profile> -d <build_folder> -C <cohort_name>
 ```
 
 ### Testing

--- a/oncodrive3d_pipeline/modules/o3d_chimerax_plot.nf
+++ b/oncodrive3d_pipeline/modules/o3d_chimerax_plot.nf
@@ -1,7 +1,7 @@
 process O3D_CHIMERAX_PLOT {
     tag "ChimeraX plot $cohort"
     publishDir "${params.outdir}/${params.outsubdir}", mode:'copy'
-    container 'docker.io/spellegrini87/oncodrive3d_chimerax:latest'
+    container 'docker.io/spellegrini87/oncodrive3d:chimerax'
 
     input:
     tuple val(cohort), path(inputs), path(genes_csv), path(pos_csv), path(mutations_csv), path(miss_prob_json), path(seq_df_tsv)

--- a/oncodrive3d_pipeline/modules/o3d_plot.nf
+++ b/oncodrive3d_pipeline/modules/o3d_plot.nf
@@ -1,7 +1,7 @@
 process O3D_PLOT {
     tag "Plot $cohort"
     publishDir "${params.outdir}/${params.outsubdir}", mode:'copy'
-    container 'docker.io/bbglab/oncodrive3d:latest'
+    container 'docker.io/spellegrini87/oncodrive3d:latest'
 
     input:
     tuple val(cohort), path(inputs), path(genes_csv), path(pos_csv), path(mutations_csv), path(miss_prob_json), path(seq_df_tsv)

--- a/oncodrive3d_pipeline/modules/o3d_run.nf
+++ b/oncodrive3d_pipeline/modules/o3d_run.nf
@@ -1,7 +1,7 @@
 process O3D_RUN {
     tag "O3D $cohort"
     publishDir "${params.outdir}/${params.outsubdir}", mode:'copy'
-    container 'docker.io/bbglab/oncodrive3d:latest'
+    container 'docker.io/spellegrini87/oncodrive3d:latest'
 
     input:
     tuple val(cohort), path(inputs)

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,2 +1,2 @@
 __logger_name__ = 'oncodrive3d'
-__version__ = "1.0.8"
+__version__ = "1.0.9"

--- a/tools/release/docker.sh
+++ b/tools/release/docker.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+#
+# Build and push all three Oncodrive3D Docker image variants in one shot.
+#
+# Usage:
+#   ./tools/release/docker.sh <version> <repo>
+#
+# Examples:
+#   ./tools/release/docker.sh 1.0.9 spellegrini87/oncodrive3d
+#   ./tools/release/docker.sh 1.0.9 bbglab/oncodrive3d
+#
+# Prerequisites:
+#   - Logged in to Docker Hub for <repo> (`docker login`).
+#   - `chimerax.deb` staged in the repo root (used by the chimerax and full
+#     variants — see Dockerfile).
+
+set -euo pipefail
+
+VERSION="${1:?usage: docker.sh <version> <repo>}"
+REPO="${2:?usage: docker.sh <version> <repo>}"
+
+# Run from the repo root so `chimerax.deb` and the Dockerfile resolve.
+cd "$(dirname "$0")/../.."
+
+if [[ ! -f chimerax.deb ]]; then
+    cat <<EOF >&2
+Missing chimerax.deb in repo root ($(pwd)).
+
+Download the Ubuntu 20.04 ChimeraX .deb from:
+  https://www.cgl.ucsf.edu/chimerax/download.html
+
+and save it as: $(pwd)/chimerax.deb
+EOF
+    exit 1
+fi
+
+docker build --target light    -f Dockerfile \
+    -t "${REPO}:${VERSION}"          -t "${REPO}:latest" \
+    -t "${REPO}:${VERSION}-light"    -t "${REPO}:light"    .
+
+docker build --target chimerax -f Dockerfile \
+    -t "${REPO}:${VERSION}-chimerax" -t "${REPO}:chimerax" .
+
+docker build --target full     -f Dockerfile \
+    -t "${REPO}:${VERSION}-full"     -t "${REPO}:full"     .
+
+docker push "${REPO}" --all-tags
+
+echo
+echo "Released ${VERSION} to ${REPO}. Tags now on Docker Hub:"
+docker images "${REPO}" --format "  {{.Tag}}"

--- a/tools/release/docker.sh
+++ b/tools/release/docker.sh
@@ -26,10 +26,17 @@ if [[ ! -f chimerax.deb ]]; then
     cat <<EOF >&2
 Missing chimerax.deb in repo root ($(pwd)).
 
-Download the Ubuntu 20.04 ChimeraX .deb from:
-  https://www.cgl.ucsf.edu/chimerax/download.html
+Save the Ubuntu 20.04 ChimeraX .deb installer as:
+  $(pwd)/chimerax.deb
 
-and save it as: $(pwd)/chimerax.deb
+How to get it:
+
+  External users:
+    Download from https://www.cgl.ucsf.edu/chimerax/download.html
+
+  BBGLab internal users:
+    Download from the lab cluster path:
+      /data/bbg/datasets/oncodrive3d/chimerax/chimerax-rc_2004.deb
 EOF
     exit 1
 fi

--- a/tools/release/docker.sh
+++ b/tools/release/docker.sh
@@ -41,18 +41,42 @@ EOF
     exit 1
 fi
 
-docker build --target light    -f Dockerfile \
-    -t "${REPO}:${VERSION}"          -t "${REPO}:latest" \
-    -t "${REPO}:${VERSION}-light"    -t "${REPO}:light"    .
+LIGHT_TAGS=(
+    "${REPO}:${VERSION}"
+    "${REPO}:latest"
+    "${REPO}:${VERSION}-light"
+    "${REPO}:light"
+)
+CHIMERAX_TAGS=(
+    "${REPO}:${VERSION}-chimerax"
+    "${REPO}:chimerax"
+)
+FULL_TAGS=(
+    "${REPO}:${VERSION}-full"
+    "${REPO}:full"
+)
 
-docker build --target chimerax -f Dockerfile \
-    -t "${REPO}:${VERSION}-chimerax" -t "${REPO}:chimerax" .
+# Expand a tag array into `-t tag1 -t tag2 ...` for docker build.
+build_tag_args() {
+    local args=() tag
+    for tag in "$@"; do args+=(-t "$tag"); done
+    printf '%s\n' "${args[@]}"
+}
 
-docker build --target full     -f Dockerfile \
-    -t "${REPO}:${VERSION}-full"     -t "${REPO}:full"     .
+mapfile -t LIGHT_BUILD_ARGS    < <(build_tag_args "${LIGHT_TAGS[@]}")
+mapfile -t CHIMERAX_BUILD_ARGS < <(build_tag_args "${CHIMERAX_TAGS[@]}")
+mapfile -t FULL_BUILD_ARGS     < <(build_tag_args "${FULL_TAGS[@]}")
 
-docker push "${REPO}" --all-tags
+docker build --target light    -f Dockerfile "${LIGHT_BUILD_ARGS[@]}"    .
+docker build --target chimerax -f Dockerfile "${CHIMERAX_BUILD_ARGS[@]}" .
+docker build --target full     -f Dockerfile "${FULL_BUILD_ARGS[@]}"     .
+
+# Push only the tags created above; avoid `--all-tags` so stale local tags
+# (e.g. from prior releases) are not silently re-published.
+for tag in "${LIGHT_TAGS[@]}" "${CHIMERAX_TAGS[@]}" "${FULL_TAGS[@]}"; do
+    docker push "${tag}"
+done
 
 echo
-echo "Released ${VERSION} to ${REPO}. Tags now on Docker Hub:"
-docker images "${REPO}" --format "  {{.Tag}}"
+echo "Released ${VERSION} to ${REPO}. Tags pushed:"
+printf '  %s\n' "${LIGHT_TAGS[@]}" "${CHIMERAX_TAGS[@]}" "${FULL_TAGS[@]}"


### PR DESCRIPTION
## Summary

Until now Oncodrive3D shipped two Docker variants:

- `bbglab/oncodrive3d` — supported `run`, `build-datasets`, and standard `plot`
- `bbglab/oncodrive3d_chimerax` — supported `chimerax-plot` only

Neither variant included PDB_Tool, so `build-annotations` was not runnable inside a container at all.

This PR consolidates the two images into a single multi-target Dockerfile and adds a third variant that brings full feature parity, including `build-annotations`:

| Variant  | Approx size | Supported commands |
| -------- | ----------- | ------------------ |
| Light    | ~1.5 GB     | `run`, `plot` |
| ChimeraX | ~4.3 GB     | + `chimerax-plot` |
| Full     | ~16 GB      | + `build-datasets`, `build-annotations` |

The variants stack via `FROM <previous> AS <next>`, so layers are shared across images and switching tags only downloads the delta. PDB_Tool is compiled from source in a dedicated stage and copied into the `full` image.

The light variant is also lighter than the previous default: HPC/Nextflow users running only `oncodrive3d run` pull ~1.5 GB instead of the previous ~13 GB (no pre-fetched bgdata caches, no ChimeraX).

## Changes

- `Dockerfile` — multi-target build:
  - Wheel built once in a shared `build-stage`.
  - `pdb-tool-stage` compiles PDB_Tool from source (only pulled in by `full`, enabling `build-annotations` in a container for the first time).
  - `light`, `chimerax`, and `full` targets, each layered on the previous.
  - Base switched to `python:3.10-bullseye` (Debian 11), which provides Python 3.10 plus `libssl1.1`/`libffi7` needed by the Ubuntu 20.04 ChimeraX `.deb`.
- `Dockerfile.chimerax` removed (subsumed by the multi-target Dockerfile).
- `.gitignore` — ignore staged `chimerax*.deb` installers.
- `README.md` — new "Container Images" section with the variant table, Docker + Singularity examples, blockquote-style Citation block, new Credits section, and assorted markdown lint cleanups.

## Test plan

- [x] Local smoke tests for all three targets (`--version`, `which oncodrive3d`, `which chimerax`, `which PDB_Tool`, `/bgdatacache` presence per variant)
- [x] ChimeraX runs in offscreen mode inside the chimerax/full images
- [ ] Push images to Docker Hub and run a real cohort on the cluster