### PR TITLE
fix: redirect HOME to /tmp in Nextflow env so ChimeraX can write its data dir

### DIFF
--- a/oncodrive3d_pipeline/modules/o3d_chimerax_plot.nf
+++ b/oncodrive3d_pipeline/modules/o3d_chimerax_plot.nf
@@ -15,6 +15,12 @@ process O3D_CHIMERAX_PLOT {
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${cohort}"
     """
+    # Give ChimeraX a writable, per-task HOME so it can initialise its data
+    # directory (\$HOME/.chimerax) without colliding with concurrent tasks or
+    # hitting a read-only host \$HOME inside Singularity.
+    export HOME="\$PWD/.chimerax-home"
+    mkdir -p "\$HOME"
+
     oncodrive3D chimerax-plot \\
         -o $prefix \\
         -g $genes_csv \\

--- a/oncodrive3d_pipeline/nextflow.config
+++ b/oncodrive3d_pipeline/nextflow.config
@@ -123,7 +123,7 @@ process {
 
 // Export these variables to prevent local Python/R libraries from conflicting with those in the container
 // HOME is redirected to /tmp so ChimeraX can write its per-user data dir
-// (the host $HOME is typically passed through read-only by Singularity).
+// (on many clusters the host $HOME path is not writable inside the container).
 env {
     PYTHONNOUSERSITE = 1
     R_PROFILE_USER   = "/.Rprofile"

--- a/oncodrive3d_pipeline/nextflow.config
+++ b/oncodrive3d_pipeline/nextflow.config
@@ -122,11 +122,14 @@ process {
 }
 
 // Export these variables to prevent local Python/R libraries from conflicting with those in the container
+// HOME is redirected to /tmp so ChimeraX can write its per-user data dir
+// (the host $HOME is typically passed through read-only by Singularity).
 env {
     PYTHONNOUSERSITE = 1
     R_PROFILE_USER   = "/.Rprofile"
     R_ENVIRON_USER   = "/.Renviron"
     JULIA_DEPOT_PATH = "/usr/local/share/julia"
+    HOME             = "/tmp"
 }
 
 // Nextflow runtime settings

--- a/oncodrive3d_pipeline/nextflow.config
+++ b/oncodrive3d_pipeline/nextflow.config
@@ -122,14 +122,11 @@ process {
 }
 
 // Export these variables to prevent local Python/R libraries from conflicting with those in the container
-// HOME is redirected to /tmp so ChimeraX can write its per-user data dir
-// (on many clusters the host $HOME path is not writable inside the container).
 env {
     PYTHONNOUSERSITE = 1
     R_PROFILE_USER   = "/.Rprofile"
     R_ENVIRON_USER   = "/.Renviron"
     JULIA_DEPOT_PATH = "/usr/local/share/julia"
-    HOME             = "/tmp"
 }
 
 // Nextflow runtime settings


### PR DESCRIPTION
## Summary

ChimeraX initializes a per-user data dir at `$HOME/.chimerax/` on first invocation. Singularity passes the host `$HOME` through to the container; on most clusters that path is read-only inside the container, so ChimeraX fails with `Unable to make user's data directory: Read-only file system` and silently produces no PNG output during `chimerax-plot`.

Override `HOME=/tmp` at the pipeline `env` level so ChimeraX has a writable home regardless of host config.