### PR TITLE
fix: robust plotting (empty/+inf) and corrupt contact-map handling

### DIFF
--- a/docs/run_input_output.md
+++ b/docs/run_input_output.md
@@ -178,6 +178,7 @@ CSV file (`<cohort>.3d_clustering_genes.csv`) containing the results of the anal
 - `No_density`: The maximum number of mutations in the spatial volume of any residue is one or less.
 - `No_ID_mapping`: No corresponding UniProt ID is found for the given gene in the Oncodrive3D built datasets.
 - `Cmap_not_found`: The contact map for the gene's structural data is not available.
+- `Cmap_corrupted`: The contact map file exists but could not be loaded (e.g. empty or truncated from an interrupted build).
 - `Mut_not_in_structure`: The proportion of mutations mapped to positions outside the boundaries of the provided PDB structure exceeds the threshold for mapping issues (`--thr_mapping_issue`, default: `0.1`).
 - `WT_mismatch`: The proportion of mutations in the input file where the wild-type amino acid does not match the corresponding residue in the structural model exceeds the threshold for mapping issues (`--thr_mapping_issue`, default: `0.1`).
 - `Mut_with_zero_prob`: The proportion of mutations mapped to positions with a mutation probability of zero exceeds the threshold for mapping issues (`--thr_mapping_issue`, default: `0.1`).

--- a/scripts/plotting/chimerax_plot.py
+++ b/scripts/plotting/chimerax_plot.py
@@ -289,16 +289,14 @@ def generate_chimerax_plot(output_dir,
                     "logscore" : "Logscore_obs_sim"}                                            
             
             if fragmented_proteins == False:
-                if f != 1:
+                if str(f) != "1":
                     logger.debug(f"Fragmented protein processing {fragmented_proteins}: Skipping {gene} ({uni_id}-F{f})..")
                     continue
                 
             if pdb_path:
 
-                # Mutated rows = rows the .defattr file is written from = the
-                # residues that actually receive a colour from `color byattribute`.
-                # Compute once and reuse so the sphere-render selection stays
-                # coupled to the .defattr contents.
+                # Mutated rows: the residues written to the .defattr file and
+                # thus coloured. Reused below so the spheres match the colours.
                 result_gene_mutated = result_gene.dropna()
                 colored_positions = result_gene_mutated["Pos"].astype(int).tolist()
 

--- a/scripts/plotting/chimerax_plot.py
+++ b/scripts/plotting/chimerax_plot.py
@@ -234,6 +234,9 @@ def generate_chimerax_plot(output_dir,
     seq_df = pd.read_csv(seq_df_path, sep="\t")
     gene_result = pd.read_csv(gene_result_path)
     result = pd.read_csv(pos_result_path)
+    if result.empty:
+        logger.warning("Empty position-level result; nothing to plot.")
+        return
     if "Ratio_obs_sim" in result.columns:
         result = result.rename(columns={"Ratio_obs_sim" : "Score_obs_sim"})
     result = cap_inf_scores(result)

--- a/scripts/plotting/plot.py
+++ b/scripts/plotting/plot.py
@@ -2309,7 +2309,12 @@ def generate_plots(gene_result_path,
 
     gene_result = pd.read_csv(gene_result_path)
     pos_result = pd.read_csv(pos_result_path)
-    pos_result = cap_inf_scores(pos_result)
+    if pos_result.empty:
+        logger.warning("Empty position-level result; nothing to plot.")
+        return
+    # NB: pos_result is kept uncapped so the saved annotated CSV preserves the
+    # original +inf scores. Capping is applied locally only where a plot
+    # consumes Score_obs_sim (summary_plot, genes_plots).
     maf = pd.read_csv(maf_path, sep="\t")
     miss_prob_dict = json.load(open(miss_prob_path))  
     seq_df = pd.read_csv(seq_df_path, sep="\t")    
@@ -2347,8 +2352,8 @@ def generate_plots(gene_result_path,
         os.makedirs(output_dir, exist_ok=True)
         logger.info(f"Generating summary plot in {output_dir}")
         count_mut_gene_df, count_pos_df, cluster_df = get_summary_counts(gene_result, pos_result, seq_df)
-        summary_plot(gene_result, 
-                     pos_result, 
+        summary_plot(gene_result,
+                     cap_inf_scores(pos_result),
                      count_mut_gene_df, 
                      count_pos_df, 
                      cluster_df,
@@ -2376,8 +2381,8 @@ def generate_plots(gene_result_path,
                                                                         lst_genes)
         
         if c_genes_only == False or (c_genes_only and n_genes > 1):
-            pos_result_annotated, uni_feat_processed = genes_plots(gene_result, 
-                                                                    pos_result, 
+            pos_result_annotated, uni_feat_processed = genes_plots(gene_result,
+                                                                    cap_inf_scores(pos_result),
                                                                     seq_df,
                                                                     maf,
                                                                     maf_nonmiss,

--- a/scripts/plotting/utils.py
+++ b/scripts/plotting/utils.py
@@ -61,9 +61,9 @@ def cap_inf_scores(pos_result, col="Score_obs_sim"):
         f"Capping {n_inf} `{col}` value(s) at {cap:.4f} for plotting "
         f"(originally +inf — extreme hotspot positions)"
     )
-    # Write the whole numeric column back so the returned frame has a numeric
-    # dtype (downstream np.log/scaling stay safe). .copy() prevents the in-place
-    # edit from leaking into the caller's uncapped frame via a to_numeric view.
+    # Write back the whole numeric column so the returned frame is numeric dtype.
+    # .copy() is required: pd.to_numeric can share the caller's buffer, so an
+    # in-place edit would corrupt the uncapped frame.
     numeric_col = numeric_col.copy()
     numeric_col.loc[inf_mask] = cap
     pos_result = pos_result.copy()

--- a/scripts/plotting/utils.py
+++ b/scripts/plotting/utils.py
@@ -30,17 +30,22 @@ def cap_inf_scores(pos_result, col="Score_obs_sim"):
     We cap +inf at 1.5 * max(finite) so the point stays visible at the top of
     the y-axis without distorting the rest of the track.
     """
-    if col not in pos_result.columns:
+    if col not in pos_result.columns or pos_result.empty:
         return pos_result
+
+    # Coerce to numeric first: a header-only result CSV (e.g. a control cohort
+    # with no processed genes) reads back with object-dtype columns, which
+    # np.isposinf rejects. errors='coerce' turns any non-numeric cell into NaN.
+    numeric_col = pd.to_numeric(pos_result[col], errors="coerce")
 
     # Only +inf is expected here (the score is bounded below by 0); use the
     # positive-only check so any future -inf sentinel is preserved instead of
     # silently rewritten.
-    inf_mask = np.isposinf(pos_result[col])
+    inf_mask = np.isposinf(numeric_col)
     if not inf_mask.any():
         return pos_result
 
-    finite_values = pos_result.loc[~inf_mask, col]
+    finite_values = numeric_col[~inf_mask]
     finite_max = finite_values.max() if not finite_values.empty else np.nan
     if pd.notna(finite_max) and finite_max > 0:
         cap = finite_max * 1.5

--- a/scripts/plotting/utils.py
+++ b/scripts/plotting/utils.py
@@ -61,8 +61,13 @@ def cap_inf_scores(pos_result, col="Score_obs_sim"):
         f"Capping {n_inf} `{col}` value(s) at {cap:.4f} for plotting "
         f"(originally +inf — extreme hotspot positions)"
     )
+    # Write the whole numeric column back so the returned frame has a numeric
+    # dtype (downstream np.log/scaling stay safe). .copy() prevents the in-place
+    # edit from leaking into the caller's uncapped frame via a to_numeric view.
+    numeric_col = numeric_col.copy()
+    numeric_col.loc[inf_mask] = cap
     pos_result = pos_result.copy()
-    pos_result.loc[inf_mask, col] = cap
+    pos_result[col] = numeric_col
     return pos_result
 
 

--- a/scripts/plotting/utils.py
+++ b/scripts/plotting/utils.py
@@ -21,14 +21,10 @@ def cap_inf_scores(pos_result, col="Score_obs_sim"):
     """
     Replace +inf values in a score column with a saturated finite value.
 
-    `Score_obs_sim` is +inf for extreme hotspot positions where the observed
-    anomaly score is at the mathematical limit (the high-precision Decimal
-    fallback in score_and_simulations.get_dcm_anomaly_score returns +inf when
-    even 600-digit precision underflows). +inf breaks downstream plotting:
-    normalization (sum=inf), log transforms, and axis auto-scaling.
-
-    We cap +inf at 1.5 * max(finite) so the point stays visible at the top of
-    the y-axis without distorting the rest of the track.
+    `Score_obs_sim` is +inf for extreme hotspot positions (the Decimal fallback
+    in score_and_simulations underflows even at 600-digit precision), which
+    breaks downstream plotting (normalization, log transforms, axis scaling).
+    We cap it at 1.5 * max(finite): visible at the top of the track, no distortion.
     """
     if col not in pos_result.columns or pos_result.empty:
         return pos_result

--- a/scripts/run/clustering.py
+++ b/scripts/run/clustering.py
@@ -187,7 +187,12 @@ def clustering_3d(gene,
     # Load cmap
     cmap_complete_path = f"{cmap_path}/{uniprot_id}-F{af_f}.npy"
     if os.path.isfile(cmap_complete_path):
-        cmap = np.load(cmap_complete_path) 
+        try:
+            cmap = np.load(cmap_complete_path)
+        except (EOFError, ValueError, OSError) as e:
+            logger.warning(f"Could not load cmap for {gene} ({uniprot_id}-F{af_f}): {e}. Skipping..")
+            result_gene_df["Status"] = "Cmap_corrupted"
+            return None, result_gene_df
         cmap = cmap > cmap_prob_thr
         cmap = cmap.astype(int)
     else:


### PR DESCRIPTION
This PR bundles three robustness fixes for the plotting and run steps.

When a control cohort produces no processable genes, Oncodrive3D writes a position-level result file with only a header and no rows. Plotting then crashed, because reading a header-only CSV gives columns of object type, and `cap_inf_scores` can't run `np.isposinf` on those. This PR makes both plot entry points (`generate_plots` and `generate_chimerax_plot`) check for an empty result up front and skip plotting with a warning, and it also hardens `cap_inf_scores` itself so it bails out on empty input and coerces the column to numeric before checking for infinities.

While fixing this I also addressed a related issue: the score for extreme hotspot positions can legitimately be `+inf`, and we cap that value only so the plots look right. Previously the capped value was leaking into the saved `*.3d_clustering_pos.annotated.csv`, so the final table no longer showed the real infinite score. Now `pos_result` is kept untouched all the way to where it's saved, and capping happens only on the copies handed to the plotting functions. The annotated CSV keeps the original `+inf`.

Separately, a corrupt or truncated contact-map file (e.g. a zero-byte `.npy` left by an interrupted dataset build) used to abort an entire cohort run: a *missing* cmap was handled gracefully, but a *present-but-unreadable* one raised `EOFError` from `np.load` and killed every gene. The run now catches that, logs a warning, flags the gene with a new `Cmap_corrupted` status, and continues with the remaining genes.

## Problem
- Control cohorts (no processed genes) write a header-only `3d_clustering_pos.csv`. `pd.read_csv` yields object-dtype columns, so `cap_inf_scores` crashed on `np.isposinf`.
- Capping was applied to `pos_result` globally, so the saved `*.annotated.csv` stored the capped value instead of the original `+inf`.
- A single corrupt/empty contact-map `.npy` aborted the whole cohort run instead of skipping just that gene.

## Fix
- **Empty guard:** `generate_plots` and `generate_chimerax_plot` now warn and return on an empty result CSV.
- **Robust cap:** `cap_inf_scores` returns early on empty input and coerces to numeric before `np.isposinf`.
- **Preserve inf:** removed the global cap; `pos_result` stays uncapped through to `save_annotated_result`, with capping applied inline only at the plot consumers (`summary_plot`, `genes_plots`).
- **Corrupt cmap:** `clustering_3d` wraps `np.load` and skips genes whose contact map can't be read, with a new `Cmap_corrupted` status (documented in `run_input_output.md`).
