### PR TITLE
feat: improve ChimeraX plots

### DIFF
--- a/docs/annotations_plotting.md
+++ b/docs/annotations_plotting.md
@@ -151,7 +151,14 @@ Only raw p-values are provided; apply your preferred multiple-testing correction
 
 ### ChimeraX 3D Snapshots
 
-For interactive-ready 3D views, Oncodrive3D exposes a separate `oncodrive3d chimerax-plot` command. It takes the same gene/position-level CSVs produced by `oncodrive3d run`, plus the datasets directory (for AlphaFold structures) and the processed sequence dataframe, and renders PNG snapshots together with `.defattr` files under `<output_dir>/<cohort>.chimerax/`. Each snapshot shows the AlphaFold model with significant clusters highlighted, optional extended clusters, pLDDT coloring, and sample counts. Provide the path to your ChimeraX installation via `--chimerax_bin` or rely on the default `/usr/bin/chimerax`. The Nextflow pipeline exposes the same functionality through the `chimerax_plot` flag.
+For interactive-ready 3D views, Oncodrive3D exposes a separate `oncodrive3d chimerax-plot` command. It takes the same gene/position-level CSVs produced by `oncodrive3d run`, plus the datasets directory (for AlphaFold structures) and the processed sequence dataframe, and renders PNG snapshots together with `.defattr` files under `<output_dir>/<cohort>.chimerax/`. Each snapshot shows the AlphaFold model coloured by a mutation or clustering metric (mutations in residue, mutations in volume, clustering score, log clustering score), with the mutated or cluster residues highlighted as spheres. The Nextflow pipeline exposes the same functionality through the `chimerax_plot` flag.
+
+> [!NOTE]
+> **ChimeraX must be installed separately.** The framework was tested with **ChimeraX 1.6.1** (`ucsf-chimerax_1.6.1ubuntu20.04_amd64.deb` from [UCSF older releases](https://www.cgl.ucsf.edu/chimerax/older_releases.html); newer releases should also work).
+>
+> If instead you run Oncodrive3D through the provided `chimerax` or `full` Docker image, ChimeraX is already included — no separate install needed.
+>
+> By default the command looks for the executable at `/usr/bin/chimerax`; pass `--chimerax_bin` if yours is elsewhere.
 
 Example:
 
@@ -173,10 +180,13 @@ See `oncodrive3d chimerax-plot --help` for all options.
 
 **Worth knowing:**
 
-- `--chimerax_bin` defaults to `/usr/bin/chimerax`; override it if ChimeraX is installed elsewhere or running in a container.
 - `--pixel_size` controls resolution — smaller values produce larger images (default `0.08`).
 - `--cluster_ext` displays extended clusters (mutations that contribute to but don't directly form significant clusters).
-- `--af_version` defaults to `6` (matching `build-datasets`). Pass it only if your datasets were built with a different version (e.g., `--af_version 4` for MANE builds).
+- `--af_version` is auto-detected from the structures in the datasets directory, so you normally don't set it. It's used only as a tiebreaker when the dataset contains more than one AlphaFold version, or as a fallback if none is detected (default `6`).
+- `--spheres` / `--no-spheres` (default on) highlights residues as spheres — mutated residues on the base plots, cluster residues on the `*_clusters` plots. With `--no-spheres` the base plots are cartoon-only while the `*_clusters` plots still mark the clusters.
+- `--cluster_markers` (default off) adds translucent volume bubbles on the cluster residues in the `*_clusters` plots.
+- `--non_mutated_color` (default `gray`) and `--text_color` (default `black`) set the colour of the non-mutated cartoon and of the title / color-bar label (any ChimeraX colour name or hex).
+- `--transparent_bg` / `--no-transparent_bg` (default on) saves images with a transparent background; pass `--no-transparent_bg` for a white background.
 
 ---
 

--- a/docs/annotations_plotting.md
+++ b/docs/annotations_plotting.md
@@ -156,7 +156,7 @@ For interactive-ready 3D views, Oncodrive3D exposes a separate `oncodrive3d chim
 > [!NOTE]
 > **ChimeraX must be installed separately.** The framework was tested with **ChimeraX 1.6.1** (`ucsf-chimerax_1.6.1ubuntu20.04_amd64.deb` from [UCSF older releases](https://www.cgl.ucsf.edu/chimerax/older_releases.html); newer releases should also work).
 >
-> If instead you run Oncodrive3D through the provided `chimerax` or `full` Docker image, ChimeraX is already included — no separate install needed.
+> If instead you run Oncodrive3D through the provided `chimerax` or `full` Docker image, ChimeraX is already included, so no separate install is needed.
 >
 > By default the command looks for the executable at `/usr/bin/chimerax`; pass `--chimerax_bin` if yours is elsewhere.
 
@@ -183,7 +183,7 @@ See `oncodrive3d chimerax-plot --help` for all options.
 - `--pixel_size` controls resolution — smaller values produce larger images (default `0.08`).
 - `--cluster_ext` displays extended clusters (mutations that contribute to but don't directly form significant clusters).
 - `--af_version` is auto-detected from the structures in the datasets directory, so you normally don't set it. It's used only as a tiebreaker when the dataset contains more than one AlphaFold version, or as a fallback if none is detected (default `6`).
-- `--spheres` / `--no-spheres` (default on) highlights residues as spheres — mutated residues on the base plots, cluster residues on the `*_clusters` plots. With `--no-spheres` the base plots are cartoon-only while the `*_clusters` plots still mark the clusters.
+- `--spheres` / `--no-spheres` (default on) highlights residues as spheres: mutated residues on the base plots, cluster residues on the `*_clusters` plots. With `--no-spheres` the base plots are cartoon-only while the `*_clusters` plots still mark the clusters.
 - `--cluster_markers` (default off) adds translucent volume bubbles on the cluster residues in the `*_clusters` plots.
 - `--non_mutated_color` (default `gray`) and `--text_color` (default `black`) set the colour of the non-mutated cartoon and of the title / color-bar label (any ChimeraX colour name or hex).
 - `--transparent_bg` / `--no-transparent_bg` (default on) saves images with a transparent background; pass `--no-transparent_bg` for a white background.

--- a/docs/annotations_plotting.md
+++ b/docs/annotations_plotting.md
@@ -1,22 +1,19 @@
 # Annotation Build & Plotting Workflow
 
-Oncodrive3D ships with a plotting pipeline that turns the clustering results into analysis-ready visualizations and enriched tables. Its goal is threefold: 
-1. help you interpret **why** a gene or residue achieved a significant 3D-clustering signal by overlaying structural/functional context, 
-2. highlight diagnostic cues that reveal whether a signal looks biologically plausible or could be an artifact,
-3. provide downstream-analysis assets such as summary panels, per-gene tracks, volcano/log-odds association charts, and annotated CSVs to guide follow-up experiments or reporting. 
+Oncodrive3D ships with a plotting pipeline that turns the clustering results into visualizations and annotated tables. They help you interpret **why** a gene or residue scored a significant 3D-clustering signal, judge whether that signal looks biologically plausible or artifactual, and produce downstream assets (summary panels, per-gene tracks, association charts, annotated CSVs) for follow-up.
 
-To keep the runtime reasonable, structural and functional annotations are generated once per dataset via `oncodrive3d build-annotations`, then reused by `oncodrive3d plot` for any cohort.
-
-This document describes the prerequisites, the intermediate files that are produced, and how to customize the plots.
+Annotations are built once per dataset via `oncodrive3d build-annotations`, then reused by `oncodrive3d plot` for any cohort.
 
 ---
 
 ## Prerequisites
 
-1. **Datasets** – `oncodrive3d build-datasets` (or `build-datasets --mane_only`) must have been run already; the plotting stage reads `datasets/pdb_structures`, `seq_for_mut_prob.tsv`, and `confidence.tsv`.
+Building the annotation bundle (`oncodrive3d build-annotations`) is the demanding step and needs all of the following. Plotting (`oncodrive3d plot`) needs only items 1 and 2, plus the annotation bundle and the outputs of an `oncodrive3d run` (listed under [Generating Plots](#generating-plots)).
+
+1. **Datasets** – `oncodrive3d build-datasets` (or `build-datasets --mane_only`) must have been run already. Both steps read from this folder (`build-annotations` uses `pdb_structures` and `seq_for_mut_prob.tsv`; `plot` uses `confidence.tsv` and `seq_for_mut_prob.tsv`).
 2. **Python environment** – use the same environment (e.g., `uv` virtualenv) that you rely on for the CLI.
 3. **PDB_Tool binary** – `oncodrive3d build-annotations` invokes the [PDB_Tool](https://github.com/realbigws/PDB_Tool) executable named `PDB_Tool` on `$PATH` to compute per-residue solvent accessibility and secondary structure. See **Installing PDB_Tool** below for a recipe.
-4. **Internet access** – required to download Pfam annotations, UniProt features, and (if `--ddg_dir` is not set) RaSP ΔΔG predictions. You can point `--ddg_dir` to precomputed RaSP files to skip the download step or to provide in-house predicted scores.
+4. **Internet access** – required to download Pfam annotations, UniProt features, and (unless `--ddg_dir` is set) RaSP ΔΔG predictions.
 5. **Disk space** – annotation folders contain many files; keep several GB free.
 
 ### Installing PDB_Tool
@@ -58,24 +55,22 @@ See `oncodrive3d build-annotations --help` for all options.
 
 **Worth knowing:**
 
-- ΔΔG predictions default to the public RaSP bundle (computed against the canonical AlphaFold v4 human proteome — not the MANE bundle). For datasets built with a different AF version, residue-level mismatches are filtered during validation (see `--ddg_mismatch_threshold` below).
-- `--ddg_dir` overrides the default download with a folder of RaSP-style CSVs (columns `variant` and `score_ml`; UniProt accession auto-detected anywhere in the filename, any separator). For non-human organisms the public bundle doesn't apply, so without `--ddg_dir` the ΔΔG step is skipped with a warning — other annotations build normally. To generate predictions yourself on CPUs, see [bbglab/rasp_cpu](https://github.com/bbglab/rasp_cpu).
+- ΔΔG predictions default to the public RaSP bundle (computed against the canonical AlphaFold v4 human proteome, not the MANE bundle). For datasets built with a different AF version, residue-level mismatches are filtered during validation (see `--ddg_mismatch_threshold` below).
+- `--ddg_dir` overrides the default download with a folder of RaSP-style CSVs (columns `variant` and `score_ml`; UniProt accession auto-detected anywhere in the filename, any separator). For non-human organisms the public bundle doesn't apply, so without `--ddg_dir` the ΔΔG step is skipped with a warning; other annotations build normally. To generate predictions yourself on CPUs, see [bbglab/rasp_cpu](https://github.com/bbglab/rasp_cpu).
 - `--ddg_mismatch_threshold` (default `0.1`) drops a protein if its wild-type residues disagree with the canonical UniProt sequence above this fraction. Set to `1.0` to disable the WT-mismatch check (positions outside the canonical sequence still drop the protein).
 - If `--output_dir` exists and isn't empty, you're prompted before its contents are cleaned (excluding `log/`); pass `--yes` to auto-confirm.
 
-What happens internally (`scripts/plotting/build_annotations.py` and helpers):
+The command assembles three annotation tracks:
 
-1. **Cleanup** – if the target directory exists and is non-empty, you're prompted before cleaning (preserving `log/`); `--yes` auto-confirms.
-2. **Stability change (ΔΔG)** – RaSP predictions are downloaded (human) or read from `--ddg_dir`. Each protein is parsed into `{position: {ALT: ddg}}` (averaging across fragments) and validated against the canonical sequence from `seq_for_mut_prob.tsv`; proteins failing validation are dropped with a warning. Within a kept protein, positions with no prediction surface as `NaN` (not `0.0`) so plots show gaps, the annotated CSV distinguishes "no data" from "neutral mutation", and the logistic regression restricts itself to real measurements.
-3. **PDB features** – AlphaFold structures are decompressed and sent through `PDB_Tool`, producing `.feature` files that are then parsed into `pdb_tool_df.tsv` with residue-level secondary structure (`SSE`) and relative accessibility (`pACC`).
-4. **Pfam domains** – Pfam coordinates are pulled from the Ensembl BioMart archive plus the Pfam ID database, merged with Oncodrive3D’s sequence metadata, and written to `pfam.tsv`.
-5. **UniProt features** – the EMBL-EBI Proteins API supplies DOMAIN/PTM/SITE/MOTIF/MEMBRANE annotations. They are normalized, merged with Pfam entries, and stored in `uniprot_feat.tsv`.
+- **Stability change (ΔΔG)** – RaSP predictions are downloaded (human) or read from `--ddg_dir`, then validated against the canonical sequence from `seq_for_mut_prob.tsv`; proteins failing validation are dropped with a warning. Positions with no prediction are kept as `NaN` (not `0.0`) so plots show gaps and the logistic regression uses only real measurements.
+- **PDB features** – AlphaFold structures are run through `PDB_Tool` into `pdb_tool_df.tsv`, with residue-level secondary structure (`SSE`) and relative accessibility (`pACC`).
+- **Domains and sites** – Pfam coordinates (Ensembl BioMart) go to `pfam.tsv`; UniProt DOMAIN/PTM/SITE/MOTIF/MEMBRANE features (EMBL-EBI Proteins API) go to `uniprot_feat.tsv`.
 
 ### Output Layout
 
 After a successful run the annotation folder contains:
 
-```
+```text
 annotations/
 ├── pdb_tool_df.tsv
 ├── pfam.tsv
@@ -85,7 +80,7 @@ annotations/
 └── log/
 ```
 
-Keep this directory around — `oncodrive3d plot` reads the tables above and merges in ΔΔG values when `stability_change/` is present, otherwise the ΔΔG track is omitted from per-gene plots and association analyses.
+Keep this directory around: `oncodrive3d plot` reads the tables above and merges in ΔΔG values when `stability_change/` is present, otherwise the ΔΔG track is omitted from per-gene plots and association analyses.
 
 ---
 
@@ -97,7 +92,7 @@ Once you have:
 - Residue-level results (`<cohort>.3d_clustering_pos.csv`),
 - Processed mutations (`<cohort>.mutations.processed.tsv`),
 - Missense probability dictionary (`<cohort>.miss_prob.processed.json`),
-- `seq_for_mut_prob.tsv`,
+- Processed sequence dataframe (`<cohort>.seq_df.processed.tsv`),
 - Built datasets (`datasets/`) and annotations (`annotations/`),
 
 call:
@@ -112,25 +107,22 @@ oncodrive3d plot \
   --datasets_dir /path/to/datasets \
   --annotations_dir /path/to/annotations \
   --output_dir plots/COHORT \
-  --cohort COHORT \
-  --maf_for_nonmiss_path original_input.maf \
-  --lst_gene_tracks miss_count,miss_prob,score,clusters,ddg,disorder,pacc,ptm,site,sse,pfam
+  --cohort COHORT
 ```
 
 See `oncodrive3d plot --help` for all options.
 
 **Worth knowing:**
 
-- `--maf_path` is the **processed missense-only** TSV (`<cohort>.mutations.processed.tsv`) from `oncodrive3d run`. `--maf_for_nonmiss_path` is optional and takes the **original** MAF (before processing) — supply it to enable the non-missense track. All other input files (gene/pos results, `--miss_prob_path`, `--seq_df_path`, `--datasets_dir`, `--annotations_dir`) must come from that same `oncodrive3d run` invocation; mismatch yields empty plots or missing-track errors.
+- `--maf_path` is the **processed missense-only** TSV (`<cohort>.mutations.processed.tsv`) from `oncodrive3d run`. `--maf_for_nonmiss_path` is optional and takes the **original** MAF (before processing); supply it to enable the non-missense track. All other input files (gene/pos results, `--miss_prob_path`, `--seq_df_path`, `--datasets_dir`, `--annotations_dir`) must come from that same `oncodrive3d run` invocation; mismatch yields empty plots or missing-track errors.
 - `--lst_summary_tracks` / `--lst_gene_tracks` accept comma-separated track names; pair them with `--lst_*_hratios` to redistribute vertical space.
 
-During execution (`scripts/plotting/plot.py`):
+The command produces:
 
-1. Results are filtered to genes requested by the user, and the corresponding entries are sliced out of the sequence/annotation tables.
-2. A **summary plot** shows per-gene mutation counts, cluster residues, and score distributions.
-3. **Per-gene plots** combine multiple tracks: observed vs expected mutation counts, missense probabilities, clustering scores, PAE/pLDDT, ΔΔG, Pfam/UniProt annotations, PTMs, membrane regions, motifs, etc. Tracks that are not available for a gene are automatically removed.
-4. Annotated tables are built by merging the positional results with disorder (pLDDT), PDB features, transcript metadata, and UniProt domains. They are saved as `<cohort>.3d_clustering_pos.annotated.csv` plus `<cohort>.uniprot_feat.tsv`.
-5. **Association plots** (optional) – see the “Association Analyses” section below for details on how the logistic-regression statistics are generated and visualized (volcano, per-gene volcano, and log-odds panels).
+- A **summary plot** of per-gene mutation counts, cluster residues, and score distributions.
+- **Per-gene plots** overlaying the requested tracks (observed vs expected mutation counts, missense probabilities, clustering scores, PAE/pLDDT, ΔΔG, Pfam/UniProt domains, PTMs, membrane regions, motifs). Tracks not available for a gene are dropped automatically.
+- **Annotated tables** (`<cohort>.3d_clustering_pos.annotated.csv` and `<cohort>.uniprot_feat.tsv`), merging the positional results with disorder (pLDDT), PDB features, transcript metadata, and UniProt domains. Written only when `--output_csv` is passed.
+- **Association plots** (optional); see the "Association Analyses" section below.
 
 ---
 
@@ -151,7 +143,7 @@ Only raw p-values are provided; apply your preferred multiple-testing correction
 
 ### ChimeraX 3D Snapshots
 
-For interactive-ready 3D views, Oncodrive3D exposes a separate `oncodrive3d chimerax-plot` command. It takes the same gene/position-level CSVs produced by `oncodrive3d run`, plus the datasets directory (for AlphaFold structures) and the processed sequence dataframe, and renders PNG snapshots together with `.defattr` files under `<output_dir>/<cohort>.chimerax/`. Each snapshot shows the AlphaFold model coloured by a mutation or clustering metric (mutations in residue, mutations in volume, clustering score, log clustering score), with the mutated or cluster residues highlighted as spheres. The Nextflow pipeline exposes the same functionality through the `chimerax_plot` flag.
+For interactive-ready 3D views, the separate `oncodrive3d chimerax-plot` command renders PNG snapshots (plus `.defattr` attribute files) under `<output_dir>/<cohort>.chimerax/`. It reuses the gene/position CSVs from `oncodrive3d run`, the datasets directory (for AlphaFold structures), and the processed sequence dataframe. Each snapshot colours the AlphaFold model by a mutation or clustering metric (mutations in residue, mutations in volume, clustering score, log clustering score), highlighting the mutated or cluster residues as spheres. The Nextflow pipeline exposes the same functionality through the `chimerax_plot` flag.
 
 > [!NOTE]
 > **ChimeraX must be installed separately.** The framework was tested with **ChimeraX 1.6.1** (`ucsf-chimerax_1.6.1ubuntu20.04_amd64.deb` from [UCSF older releases](https://www.cgl.ucsf.edu/chimerax/older_releases.html); newer releases should also work).
@@ -180,7 +172,7 @@ See `oncodrive3d chimerax-plot --help` for all options.
 
 **Worth knowing:**
 
-- `--pixel_size` controls resolution — smaller values produce larger images (default `0.08`).
+- `--pixel_size` controls resolution: smaller values produce larger images (default `0.08`).
 - `--cluster_ext` displays extended clusters (mutations that contribute to but don't directly form significant clusters).
 - `--af_version` is auto-detected from the structures in the datasets directory, so you normally don't set it. It's used only as a tiebreaker when the dataset contains more than one AlphaFold version, or as a fallback if none is detected (default `6`).
 - `--spheres` / `--no-spheres` (default on) highlights residues as spheres: mutated residues on the base plots, cluster residues on the `*_clusters` plots. With `--no-spheres` the base plots are cartoon-only while the `*_clusters` plots still mark the clusters.

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -509,7 +509,7 @@ def plot(gene_result_path,
 @click.option("--non_mutated_color", type=str, default="gray",
               help="ChimeraX color for non-mutated residues (the cartoon background)")
 @click.option("--fragmented_proteins", help="Include fragmented proteins", is_flag=True)
-@click.option("--transparent_bg", help="Set background as transparent", is_flag=True)
+@click.option("--transparent_bg/--no-transparent_bg", default=True, help="Save plots with a transparent background")
 @click.option("--chimerax_bin", help="Path to chimerax installation", type=str, default="/usr/bin/chimerax")
 @click.option("--af_version", type=click.IntRange(min=1, clamp=False), default=6,
               help="Version of AlphaFold 2 predictions used for structures")

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -502,8 +502,10 @@ def plot(gene_result_path,
 @click.option("--max_n_genes", help="Maximum number of genes to plot", type=int, default=30)
 @click.option("--pixel_size", help="Pixel size (smaller value is larger number of pixels)", type=float, default=0.08)
 @click.option("--cluster_ext", help="Include extended clusters", is_flag=True)
-@click.option("--highlight", type=click.Choice(["clusters", "mutated"]), default="clusters",
-              help="Residues to highlight as spheres: cluster residues only (default) or all mutated residues")
+@click.option("--spheres/--no-spheres", default=True,
+              help="Highlight residues as spheres: mutated residues on base plots, cluster residues on *_clusters plots (default: enabled)")
+@click.option("--cluster_markers", is_flag=True,
+              help="Add translucent volume bubbles on cluster residues in the *_clusters plots")
 @click.option("--fragmented_proteins", help="Include fragmented proteins", is_flag=True)
 @click.option("--transparent_bg", help="Set background as transparent", is_flag=True)
 @click.option("--chimerax_bin", help="Path to chimerax installation", type=str, default="/usr/bin/chimerax")
@@ -520,7 +522,8 @@ def chimerax_plot(output_dir,
                   max_n_genes,
                   pixel_size,
                   cluster_ext,
-                  highlight,
+                  spheres,
+                  cluster_markers,
                   fragmented_proteins,
                   transparent_bg,
                   chimerax_bin,
@@ -540,7 +543,8 @@ def chimerax_plot(output_dir,
     logger.info(f"Max number of genes to plot: {max_n_genes}")
     logger.info(f"Pixel size: {pixel_size}")
     logger.info(f"Cluster extended: {cluster_ext}")
-    logger.info(f"Highlight: {highlight}")
+    logger.info(f"Highlight residues as spheres: {spheres}")
+    logger.info(f"Cluster volume markers: {cluster_markers}")
     logger.info(f"Fragmented proteins: {fragmented_proteins}")
     logger.info(f"Transparent background: {transparent_bg}")
     logger.info(f"AlphaFold version: {af_version}")
@@ -561,7 +565,8 @@ def chimerax_plot(output_dir,
                         transparent_bg,
                         chimerax_bin,
                         af_version,
-                        highlight=highlight)
+                        spheres=spheres,
+                        cluster_markers=cluster_markers)
 
 if __name__ == "__main__":
     oncodrive3D()

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -503,7 +503,7 @@ def plot(gene_result_path,
 @click.option("--pixel_size", help="Pixel size (smaller value is larger number of pixels)", type=float, default=0.08)
 @click.option("--cluster_ext", help="Include extended clusters", is_flag=True)
 @click.option("--spheres/--no-spheres", default=True,
-              help="Highlight residues as spheres: mutated residues on base plots, cluster residues on *_clusters plots (default: enabled)")
+              help="Show mutated residues as spheres on the base plots. When --cluster_markers is off, the *_clusters plots show cluster residues as spheres regardless of this flag.")
 @click.option("--cluster_markers", is_flag=True,
               help="Add translucent volume bubbles on cluster residues in the *_clusters plots")
 @click.option("--fragmented_proteins", help="Include fragmented proteins", is_flag=True)

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -506,6 +506,8 @@ def plot(gene_result_path,
               help="Show mutated residues as spheres on the base plots. When --cluster_markers is off, the *_clusters plots show cluster residues as spheres regardless of this flag.")
 @click.option("--cluster_markers", is_flag=True,
               help="Add translucent volume bubbles on cluster residues in the *_clusters plots")
+@click.option("--non_mutated_color", type=str, default="gray",
+              help="ChimeraX color for non-mutated residues (the cartoon background)")
 @click.option("--fragmented_proteins", help="Include fragmented proteins", is_flag=True)
 @click.option("--transparent_bg", help="Set background as transparent", is_flag=True)
 @click.option("--chimerax_bin", help="Path to chimerax installation", type=str, default="/usr/bin/chimerax")
@@ -524,6 +526,7 @@ def chimerax_plot(output_dir,
                   cluster_ext,
                   spheres,
                   cluster_markers,
+                  non_mutated_color,
                   fragmented_proteins,
                   transparent_bg,
                   chimerax_bin,
@@ -545,6 +548,7 @@ def chimerax_plot(output_dir,
     logger.info(f"Cluster extended: {cluster_ext}")
     logger.info(f"Highlight residues as spheres: {spheres}")
     logger.info(f"Cluster volume markers: {cluster_markers}")
+    logger.info(f"Non-mutated residues color: {non_mutated_color}")
     logger.info(f"Fragmented proteins: {fragmented_proteins}")
     logger.info(f"Transparent background: {transparent_bg}")
     logger.info(f"AlphaFold version: {af_version}")
@@ -566,7 +570,8 @@ def chimerax_plot(output_dir,
                         chimerax_bin,
                         af_version,
                         spheres=spheres,
-                        cluster_markers=cluster_markers)
+                        cluster_markers=cluster_markers,
+                        non_mutated_color=non_mutated_color)
 
 if __name__ == "__main__":
     oncodrive3D()

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -508,6 +508,8 @@ def plot(gene_result_path,
               help="Add translucent volume bubbles on cluster residues in the *_clusters plots")
 @click.option("--non_mutated_color", type=str, default="gray",
               help="ChimeraX color for non-mutated residues (the cartoon background)")
+@click.option("--text_color", type=str, default="black",
+              help="ChimeraX color for the plot title and color-bar label")
 @click.option("--fragmented_proteins", help="Include fragmented proteins", is_flag=True)
 @click.option("--transparent_bg/--no-transparent_bg", default=True, help="Save plots with a transparent background")
 @click.option("--chimerax_bin", help="Path to chimerax installation", type=str, default="/usr/bin/chimerax")
@@ -527,6 +529,7 @@ def chimerax_plot(output_dir,
                   spheres,
                   cluster_markers,
                   non_mutated_color,
+                  text_color,
                   fragmented_proteins,
                   transparent_bg,
                   chimerax_bin,
@@ -549,6 +552,7 @@ def chimerax_plot(output_dir,
     logger.info(f"Highlight residues as spheres: {spheres}")
     logger.info(f"Cluster volume markers: {cluster_markers}")
     logger.info(f"Non-mutated residues color: {non_mutated_color}")
+    logger.info(f"Text color: {text_color}")
     logger.info(f"Fragmented proteins: {fragmented_proteins}")
     logger.info(f"Transparent background: {transparent_bg}")
     logger.info(f"AlphaFold version: {af_version}")
@@ -571,7 +575,8 @@ def chimerax_plot(output_dir,
                         af_version,
                         spheres=spheres,
                         cluster_markers=cluster_markers,
-                        non_mutated_color=non_mutated_color)
+                        non_mutated_color=non_mutated_color,
+                        text_color=text_color)
 
 if __name__ == "__main__":
     oncodrive3D()

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -514,7 +514,7 @@ def plot(gene_result_path,
 @click.option("--transparent_bg/--no-transparent_bg", default=True, help="Save plots with a transparent background")
 @click.option("--chimerax_bin", help="Path to chimerax installation", type=str, default="/usr/bin/chimerax")
 @click.option("--af_version", type=click.IntRange(min=1, clamp=False), default=6,
-              help="Version of AlphaFold 2 predictions used for structures")
+              help="AlphaFold version of the structures; auto-detected from the datasets, used only as a tiebreaker when several are present")
 @click.option("-v", "--verbose", help="Verbose", is_flag=True)
 @setup_logging_decorator
 def chimerax_plot(output_dir,

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -502,6 +502,8 @@ def plot(gene_result_path,
 @click.option("--max_n_genes", help="Maximum number of genes to plot", type=int, default=30)
 @click.option("--pixel_size", help="Pixel size (smaller value is larger number of pixels)", type=float, default=0.08)
 @click.option("--cluster_ext", help="Include extended clusters", is_flag=True)
+@click.option("--highlight", type=click.Choice(["clusters", "mutated"]), default="clusters",
+              help="Residues to highlight as spheres: cluster residues only (default) or all mutated residues")
 @click.option("--fragmented_proteins", help="Include fragmented proteins", is_flag=True)
 @click.option("--transparent_bg", help="Set background as transparent", is_flag=True)
 @click.option("--chimerax_bin", help="Path to chimerax installation", type=str, default="/usr/bin/chimerax")
@@ -518,6 +520,7 @@ def chimerax_plot(output_dir,
                   max_n_genes,
                   pixel_size,
                   cluster_ext,
+                  highlight,
                   fragmented_proteins,
                   transparent_bg,
                   chimerax_bin,
@@ -537,6 +540,7 @@ def chimerax_plot(output_dir,
     logger.info(f"Max number of genes to plot: {max_n_genes}")
     logger.info(f"Pixel size: {pixel_size}")
     logger.info(f"Cluster extended: {cluster_ext}")
+    logger.info(f"Highlight: {highlight}")
     logger.info(f"Fragmented proteins: {fragmented_proteins}")
     logger.info(f"Transparent background: {transparent_bg}")
     logger.info(f"AlphaFold version: {af_version}")
@@ -556,7 +560,8 @@ def chimerax_plot(output_dir,
                         fragmented_proteins,
                         transparent_bg,
                         chimerax_bin,
-                        af_version)
+                        af_version,
+                        highlight=highlight)
 
 if __name__ == "__main__":
     oncodrive3D()

--- a/scripts/plotting/chimerax_plot.py
+++ b/scripts/plotting/chimerax_plot.py
@@ -7,7 +7,7 @@ import shlex
 import subprocess
 import math
 
-import pandas as pd   
+import pandas as pd
 import numpy as np
 import daiquiri
 
@@ -143,15 +143,23 @@ def get_palette(intervals, type="diverging"):
         return f"{intervals[0]},#FFFFB2:{intervals[1]},#FECC5C:{intervals[2]},#FD8D3C:{intervals[3]},#F03B20:{intervals[4]},#BD0026"
 
 
-# Approximate fractional image width of one character in the 2dlabels font at
-# size 6 (empirically ~0.0136, near-constant across image sizes). Used to
-# horizontally centre a label instead of anchoring its left edge at a fixed x.
+# ChimeraX has no centre anchor for 2dlabels, so we estimate the text width to
+# place its left edge. The fixed color-bar labels have known widths (image
+# fraction at size 6, measured on a render); other text (the title) falls back
+# to a per-character average.
+_LABEL_FRAC = {
+    "Mutations in residue": 0.267,
+    "Mutations in volume": 0.266,
+    "Clustering score": 0.216,
+    "log(Clustering score)": 0.277,
+}
 _LABEL_CHAR_FRAC = 0.0136
 
 
 def _centered_xpos(text):
     """Left x (image fraction) that horizontally centres `text` at x=0.5."""
-    return round(0.5 - len(text) * _LABEL_CHAR_FRAC / 2, 4)
+    width = _LABEL_FRAC.get(text, len(text) * _LABEL_CHAR_FRAC)
+    return round(0.5 - width / 2, 4)
 
 
 def get_chimerax_command(chimerax_bin,

--- a/scripts/plotting/chimerax_plot.py
+++ b/scripts/plotting/chimerax_plot.py
@@ -294,9 +294,8 @@ def generate_chimerax_plot(output_dir,
                 mutated_positions = result_gene_mutated["Pos"].astype(int).tolist()
                 cluster_positions = [int(p) for p in clusters]
 
-                # Base plots sphere mutated residues, `_clusters` plots sphere
-                # cluster residues; keep cluster spheres when both toggles are
-                # off so `_clusters` still differs from its base.
+                # `_clusters` always marks the cluster: spheres unless only
+                # volume markers are requested (--no-spheres + --cluster_markers).
                 base_spheres = mutated_positions if spheres else None
                 cluster_spheres = cluster_positions if (spheres or not cluster_markers) else None
                 cluster_bubbles = cluster_positions if cluster_markers else None

--- a/scripts/plotting/chimerax_plot.py
+++ b/scripts/plotting/chimerax_plot.py
@@ -150,6 +150,7 @@ def get_chimerax_command(chimerax_bin,
                          cohort="",
                          clusters=None,
                          colored_positions=None,
+                         cluster_variant=False,
                          pixelsize=0.1,
                          transparent_bg=False):
 
@@ -176,10 +177,9 @@ def get_chimerax_command(chimerax_bin,
         "zoom;"
     )
 
-    # Render mutated (= colored) residues as spheres so their colour is actually
-    # visible on the cartoon. Without this, the colour mapping is washed out by
-    # the cartoon ribbon. ~sel afterwards clears the green selection markers
-    # from the saved image.
+    # Highlight the chosen residues as spheres so their colour pops out of the
+    # cartoon (which is otherwise washed out by the ribbon). ~sel afterwards
+    # clears the green selection markers from the saved image.
     if colored_positions is not None and len(colored_positions) > 0:
         pos_selector = ",".join(str(int(p)) for p in sorted(set(colored_positions)))
         chimerax_script += (
@@ -190,12 +190,14 @@ def get_chimerax_command(chimerax_bin,
             "~sel;"
         )
 
+    # Translucent volume markers on cluster residues (independent of the spheres).
     if clusters is not None and len(clusters) > 0:
         for pos in clusters:
             chimerax_script += f"marker #10 position :{pos} color #dacae961 radius 5.919;"
-        cluster_tag = "_clusters"
-    else:
-        cluster_tag = ""
+
+    # Filename suffix is tied to the variant, not to whether bubbles were drawn,
+    # so the `_clusters` images are always produced (stable output set).
+    cluster_tag = "_clusters" if cluster_variant else ""
 
     output_path = os.path.join(chimera_output_path, f"{cohort}_{i}_{gene}_{attribute}{cluster_tag}.png")
     _validate_chimerax_path(output_path, "output")
@@ -218,7 +220,8 @@ def generate_chimerax_plot(output_dir,
                             transparent_bg,
                             chimerax_bin,
                             af_version,
-                            highlight="clusters"):
+                            spheres=True,
+                            cluster_markers=False):
 
     seq_df = pd.read_csv(seq_df_path, sep="\t")
     gene_result = pd.read_csv(gene_result_path)
@@ -288,13 +291,15 @@ def generate_chimerax_plot(output_dir,
                 # Mutated rows: the residues written to the .defattr file and
                 # thus coloured (the whole cartoon is coloured by score regardless).
                 result_gene_mutated = result_gene.dropna()
+                mutated_positions = result_gene_mutated["Pos"].astype(int).tolist()
+                cluster_positions = [int(p) for p in clusters]
 
-                # Residues to highlight as spheres: cluster residues (reusing
-                # `clusters`, which honours --cluster_ext) or all mutated ones.
-                if highlight == "clusters":
-                    colored_positions = [int(p) for p in clusters]
-                else:
-                    colored_positions = result_gene_mutated["Pos"].astype(int).tolist()
+                # Base plots sphere mutated residues, `_clusters` plots sphere
+                # cluster residues; keep cluster spheres when both toggles are
+                # off so `_clusters` still differs from its base.
+                base_spheres = mutated_positions if spheres else None
+                cluster_spheres = cluster_positions if (spheres or not cluster_markers) else None
+                cluster_bubbles = cluster_positions if cluster_markers else None
 
                 for attribute in ["mutres", "mutvol", "score", "logscore"]:
 
@@ -322,7 +327,7 @@ def generate_chimerax_plot(output_dir,
                                                                 i,
                                                                 f,
                                                                 cohort,
-                                                                colored_positions=colored_positions,
+                                                                colored_positions=base_spheres,
                                                                 pixelsize=pixel_size,
                                                                 transparent_bg=transparent_bg)
                     except ValueError as exc:
@@ -345,8 +350,9 @@ def generate_chimerax_plot(output_dir,
                                                                     i,
                                                                     f,
                                                                     cohort,
-                                                                    clusters=clusters,
-                                                                    colored_positions=colored_positions,
+                                                                    clusters=cluster_bubbles,
+                                                                    colored_positions=cluster_spheres,
+                                                                    cluster_variant=True,
                                                                     pixelsize=pixel_size,
                                                                     transparent_bg=transparent_bg)
                         except ValueError as exc:

--- a/scripts/plotting/chimerax_plot.py
+++ b/scripts/plotting/chimerax_plot.py
@@ -182,7 +182,7 @@ def get_chimerax_command(chimerax_bin,
         f"color {non_mutated_color}; "
         f"open {attr_file_path}; "
         f"color byattribute {attribute} palette {palette}; "
-        f"key {palette} :{intervals[0]} :{intervals[1]} :{intervals[2]} :{intervals[3]} :{intervals[4]} pos 0.35,0.03 fontSize 4 size 0.3,0.02;"
+        f"key {palette} :{intervals[0]} :{intervals[1]} :{intervals[2]} :{intervals[3]} :{intervals[4]} pos 0.35,0.03 fontSize 4 size 0.3,0.02 justification right;"
         f"2dlabels create label text '{labels[attribute]}' size 6 color {text_color} xpos {_centered_xpos(labels[attribute])} ypos 0.065;"
         f"2dlabels create title text '{gene} - {uni_id}-F{f}' size 6 color {text_color} xpos {_centered_xpos(f'{gene} - {uni_id}-F{f}')} ypos 0.93;"
         "hide atoms;"

--- a/scripts/plotting/chimerax_plot.py
+++ b/scripts/plotting/chimerax_plot.py
@@ -153,7 +153,8 @@ def get_chimerax_command(chimerax_bin,
                          cluster_variant=False,
                          pixelsize=0.1,
                          transparent_bg=False,
-                         non_mutated_color="gray"):
+                         non_mutated_color="gray",
+                         text_color="black"):
 
     palette = get_palette(intervals, type="diverging") if attribute == "logscore" else get_palette(intervals, type="sequential")
     transparent_bg_suffix = " transparentBackground  true" if transparent_bg else ""
@@ -162,6 +163,7 @@ def get_chimerax_command(chimerax_bin,
     _validate_chimerax_path(pdb_path, "PDB path")
     _validate_chimerax_path(attr_file_path, "attribute file path")
     _validate_chimerax_path(non_mutated_color, "non-mutated color")
+    _validate_chimerax_path(text_color, "text color")
 
     chimerax_script = (
         f"open {pdb_path}; "
@@ -170,8 +172,8 @@ def get_chimerax_command(chimerax_bin,
         f"open {attr_file_path}; "
         f"color byattribute {attribute} palette {palette}; "
         f"key {palette} :{intervals[0]} :{intervals[1]} :{intervals[2]} :{intervals[3]} :{intervals[4]} pos 0.35,0.03 fontSize 4 size 0.3,0.02;"
-        f"2dlabels create label text '{labels[attribute]}' size 6 color darkred xpos 0.34 ypos 0.065;"
-        f"2dlabels create title text '{gene} - {uni_id}-F{f} ' size 6 color darkred xpos 0.35 ypos 0.93;"
+        f"2dlabels create label text '{labels[attribute]}' size 6 color {text_color} xpos 0.34 ypos 0.065;"
+        f"2dlabels create title text '{gene} - {uni_id}-F{f} ' size 6 color {text_color} xpos 0.35 ypos 0.93;"
         "hide atoms;"
         "show cartoons;"
         "lighting full;"
@@ -224,7 +226,8 @@ def generate_chimerax_plot(output_dir,
                             af_version,
                             spheres=True,
                             cluster_markers=False,
-                            non_mutated_color="gray"):
+                            non_mutated_color="gray",
+                            text_color="black"):
 
     seq_df = pd.read_csv(seq_df_path, sep="\t")
     gene_result = pd.read_csv(gene_result_path)
@@ -332,7 +335,8 @@ def generate_chimerax_plot(output_dir,
                                                                 colored_positions=base_spheres,
                                                                 pixelsize=pixel_size,
                                                                 transparent_bg=transparent_bg,
-                                                                non_mutated_color=non_mutated_color)
+                                                                non_mutated_color=non_mutated_color,
+                                                                text_color=text_color)
                     except ValueError as exc:
                         logger.warning(f"Skipping {gene} ({attribute}): {exc}")
                         continue
@@ -358,7 +362,8 @@ def generate_chimerax_plot(output_dir,
                                                                     cluster_variant=True,
                                                                     pixelsize=pixel_size,
                                                                     transparent_bg=transparent_bg,
-                                                                    non_mutated_color=non_mutated_color)
+                                                                    non_mutated_color=non_mutated_color,
+                                                                    text_color=text_color)
                         except ValueError as exc:
                             logger.warning(f"Skipping {gene} ({attribute}, clusters): {exc}")
                             continue

--- a/scripts/plotting/chimerax_plot.py
+++ b/scripts/plotting/chimerax_plot.py
@@ -17,11 +17,11 @@ from scripts.plotting.utils import cap_inf_scores, detect_af_version
 logger = daiquiri.getLogger(__logger_name__ + ".plotting.chimerax_plot")
 
 
-# Interpolated unquoted into the ';'-separated --cmd script, so reject chars that
-# would break or inject a command. Paths also forbid whitespace (it splits a path
-# into multiple `open` args); colors keep spaces for multi-word names ("light gray").
+# Reject chars that would break or inject into the ';'-separated --cmd script.
+# Three sets: paths/colors are interpolated unquoted, label text single-quoted.
 _CHIMERAX_UNSAFE_PATH_CHARS = ('"', ' ', '\t', ';', '\n', '\r')
 _CHIMERAX_UNSAFE_COLOR_CHARS = ('"', '\t', ';', '\n', '\r')
+_CHIMERAX_UNSAFE_TEXT_CHARS = ("'", ';', '\n', '\r')
 
 
 def _validate_chimerax_path(path, role):
@@ -37,6 +37,16 @@ def _validate_chimerax_path(path, role):
 def _validate_chimerax_color(value, role):
     """Reject colors with characters that would break/inject the ChimeraX command."""
     bad = [c for c in _CHIMERAX_UNSAFE_COLOR_CHARS if c in str(value)]
+    if bad:
+        raise ValueError(
+            f"{role} contains characters unsafe for the ChimeraX command "
+            f"script ({', '.join(repr(c) for c in bad)}): {value!r}"
+        )
+
+
+def _validate_chimerax_text(value, role):
+    """Reject 2dlabel text with characters that would break/inject the ChimeraX command."""
+    bad = [c for c in _CHIMERAX_UNSAFE_TEXT_CHARS if c in str(value)]
     if bad:
         raise ValueError(
             f"{role} contains characters unsafe for the ChimeraX command "
@@ -183,11 +193,16 @@ def get_chimerax_command(chimerax_bin,
     palette = get_palette(intervals, type="diverging") if attribute == "logscore" else get_palette(intervals, type="sequential")
     transparent_bg_suffix = " transparentBackground  true" if transparent_bg else ""
 
-    # Validate before interpolating: values go unquoted into the --cmd script.
+    label_text = labels[attribute]
+    title_text = f"{gene} - {uni_id}-F{f}"
+
+    # Validate before interpolating into the --cmd script.
     _validate_chimerax_path(pdb_path, "PDB path")
     _validate_chimerax_path(attr_file_path, "attribute file path")
     _validate_chimerax_color(non_mutated_color, "non-mutated color")
     _validate_chimerax_color(text_color, "text color")
+    _validate_chimerax_text(label_text, "label text")
+    _validate_chimerax_text(title_text, "title text")
 
     chimerax_script = (
         f"open {pdb_path}; "
@@ -196,8 +211,8 @@ def get_chimerax_command(chimerax_bin,
         f"open {attr_file_path}; "
         f"color byattribute {attribute} palette {palette}; "
         f"key {palette} :{intervals[0]} :{intervals[1]} :{intervals[2]} :{intervals[3]} :{intervals[4]} pos 0.35,0.03 fontSize 4 size 0.3,0.02 justification right;"
-        f"2dlabels create label text '{labels[attribute]}' size 6 color {text_color} xpos {_centered_xpos(labels[attribute])} ypos 0.065;"
-        f"2dlabels create title text '{gene} - {uni_id}-F{f}' size 6 color {text_color} xpos {_centered_xpos(f'{gene} - {uni_id}-F{f}')} ypos 0.93;"
+        f"2dlabels create label text '{label_text}' size 6 color {text_color} xpos {_centered_xpos(label_text)} ypos 0.065;"
+        f"2dlabels create title text '{title_text}' size 6 color {text_color} xpos {_centered_xpos(title_text)} ypos 0.93;"
         "hide atoms;"
         "show cartoons;"
         "lighting full;"

--- a/scripts/plotting/chimerax_plot.py
+++ b/scripts/plotting/chimerax_plot.py
@@ -17,13 +17,11 @@ from scripts.plotting.utils import cap_inf_scores, detect_af_version
 logger = daiquiri.getLogger(__logger_name__ + ".plotting.chimerax_plot")
 
 
-# Values are interpolated unquoted into the ';'-separated --cmd script (ChimeraX
-# rejects quoted paths in such a --cmd on some versions). Reject chars that would
-# terminate/inject a command ('"', ';', newlines). Paths also reject whitespace
-# (it would split a path into multiple `open` args); colors keep it, as ChimeraX
-# accepts multi-word names like "light gray".
+# Interpolated unquoted into the ';'-separated --cmd script, so reject chars that
+# would break or inject a command. Paths also forbid whitespace (it splits a path
+# into multiple `open` args); colors keep spaces for multi-word names ("light gray").
 _CHIMERAX_UNSAFE_PATH_CHARS = ('"', ' ', '\t', ';', '\n', '\r')
-_CHIMERAX_UNSAFE_COLOR_CHARS = ('"', ';', '\n', '\r')
+_CHIMERAX_UNSAFE_COLOR_CHARS = ('"', '\t', ';', '\n', '\r')
 
 
 def _validate_chimerax_path(path, role):

--- a/scripts/plotting/chimerax_plot.py
+++ b/scripts/plotting/chimerax_plot.py
@@ -34,7 +34,7 @@ def _validate_chimerax_path(path, role):
     bad = [c for c in _CHIMERAX_UNSAFE_PATH_CHARS if c in text]
     if bad:
         raise ValueError(
-            f"{role} path contains characters unsafe for the ChimeraX command "
+            f"{role} contains characters unsafe for the ChimeraX command "
             f"script ({', '.join(repr(c) for c in bad)}): {text!r}"
         )
 
@@ -152,19 +152,21 @@ def get_chimerax_command(chimerax_bin,
                          colored_positions=None,
                          cluster_variant=False,
                          pixelsize=0.1,
-                         transparent_bg=False):
+                         transparent_bg=False,
+                         non_mutated_color="gray"):
 
     palette = get_palette(intervals, type="diverging") if attribute == "logscore" else get_palette(intervals, type="sequential")
     transparent_bg_suffix = " transparentBackground  true" if transparent_bg else ""
 
-    # Validate before interpolating: paths go unquoted into the --cmd script.
-    _validate_chimerax_path(pdb_path, "PDB")
-    _validate_chimerax_path(attr_file_path, "attribute file")
+    # Validate before interpolating: values go unquoted into the --cmd script.
+    _validate_chimerax_path(pdb_path, "PDB path")
+    _validate_chimerax_path(attr_file_path, "attribute file path")
+    _validate_chimerax_path(non_mutated_color, "non-mutated color")
 
     chimerax_script = (
         f"open {pdb_path}; "
         "set bgColor white; "
-        "color lightgray; "
+        f"color {non_mutated_color}; "
         f"open {attr_file_path}; "
         f"color byattribute {attribute} palette {palette}; "
         f"key {palette} :{intervals[0]} :{intervals[1]} :{intervals[2]} :{intervals[3]} :{intervals[4]} pos 0.35,0.03 fontSize 4 size 0.3,0.02;"
@@ -200,7 +202,7 @@ def get_chimerax_command(chimerax_bin,
     cluster_tag = "_clusters" if cluster_variant else ""
 
     output_path = os.path.join(chimera_output_path, f"{cohort}_{i}_{gene}_{attribute}{cluster_tag}.png")
-    _validate_chimerax_path(output_path, "output")
+    _validate_chimerax_path(output_path, "output path")
     chimerax_script += f'save {output_path} pixelSize {pixelsize} supersample 3{transparent_bg_suffix};exit'
 
     # argv list for subprocess.run(shell=False) — the OS shell never sees it.
@@ -221,7 +223,8 @@ def generate_chimerax_plot(output_dir,
                             chimerax_bin,
                             af_version,
                             spheres=True,
-                            cluster_markers=False):
+                            cluster_markers=False,
+                            non_mutated_color="gray"):
 
     seq_df = pd.read_csv(seq_df_path, sep="\t")
     gene_result = pd.read_csv(gene_result_path)
@@ -328,7 +331,8 @@ def generate_chimerax_plot(output_dir,
                                                                 cohort,
                                                                 colored_positions=base_spheres,
                                                                 pixelsize=pixel_size,
-                                                                transparent_bg=transparent_bg)
+                                                                transparent_bg=transparent_bg,
+                                                                non_mutated_color=non_mutated_color)
                     except ValueError as exc:
                         logger.warning(f"Skipping {gene} ({attribute}): {exc}")
                         continue
@@ -353,7 +357,8 @@ def generate_chimerax_plot(output_dir,
                                                                     colored_positions=cluster_spheres,
                                                                     cluster_variant=True,
                                                                     pixelsize=pixel_size,
-                                                                    transparent_bg=transparent_bg)
+                                                                    transparent_bg=transparent_bg,
+                                                                    non_mutated_color=non_mutated_color)
                         except ValueError as exc:
                             logger.warning(f"Skipping {gene} ({attribute}, clusters): {exc}")
                             continue

--- a/scripts/plotting/chimerax_plot.py
+++ b/scripts/plotting/chimerax_plot.py
@@ -217,7 +217,8 @@ def generate_chimerax_plot(output_dir,
                             fragmented_proteins,
                             transparent_bg,
                             chimerax_bin,
-                            af_version):
+                            af_version,
+                            highlight="clusters"):
 
     seq_df = pd.read_csv(seq_df_path, sep="\t")
     gene_result = pd.read_csv(gene_result_path)
@@ -285,9 +286,15 @@ def generate_chimerax_plot(output_dir,
             if pdb_path:
 
                 # Mutated rows: the residues written to the .defattr file and
-                # thus coloured. Reused below so the spheres match the colours.
+                # thus coloured (the whole cartoon is coloured by score regardless).
                 result_gene_mutated = result_gene.dropna()
-                colored_positions = result_gene_mutated["Pos"].astype(int).tolist()
+
+                # Residues to highlight as spheres: cluster residues (reusing
+                # `clusters`, which honours --cluster_ext) or all mutated ones.
+                if highlight == "clusters":
+                    colored_positions = [int(p) for p in clusters]
+                else:
+                    colored_positions = result_gene_mutated["Pos"].astype(int).tolist()
 
                 for attribute in ["mutres", "mutvol", "score", "logscore"]:
 

--- a/scripts/plotting/chimerax_plot.py
+++ b/scripts/plotting/chimerax_plot.py
@@ -172,8 +172,8 @@ def get_chimerax_command(chimerax_bin,
         f"2dlabels create title text '{gene} - {uni_id}-F{f} ' size 6 color darkred xpos 0.35 ypos 0.93;"
         "hide atoms;"
         "show cartoons;"
-        "lighting soft;"
-        "graphics silhouettes true width 1.3;"
+        "lighting full;"
+        "graphics silhouettes false;"
         "zoom;"
     )
 

--- a/scripts/plotting/chimerax_plot.py
+++ b/scripts/plotting/chimerax_plot.py
@@ -288,8 +288,8 @@ def generate_chimerax_plot(output_dir,
                 
             if pdb_path:
 
-                # Mutated rows: the residues written to the .defattr file and
-                # thus coloured (the whole cartoon is coloured by score regardless).
+                # Positions written to the .defattr: only these residues get
+                # coloured by the attribute; the rest of the cartoon stays grey.
                 result_gene_mutated = result_gene.dropna()
                 mutated_positions = result_gene_mutated["Pos"].astype(int).tolist()
                 cluster_positions = [int(p) for p in clusters]

--- a/scripts/plotting/chimerax_plot.py
+++ b/scripts/plotting/chimerax_plot.py
@@ -17,25 +17,32 @@ from scripts.plotting.utils import cap_inf_scores, detect_af_version
 logger = daiquiri.getLogger(__logger_name__ + ".plotting.chimerax_plot")
 
 
-# Paths are interpolated unquoted into the ';'-separated --cmd script (ChimeraX
-# rejects quoted paths in such a --cmd on some versions), so reject characters
-# that would split a path (space, tab) or terminate the command and inject new
-# ones (';', quote, newline, CR).
+# Values are interpolated unquoted into the ';'-separated --cmd script (ChimeraX
+# rejects quoted paths in such a --cmd on some versions). Reject chars that would
+# terminate/inject a command ('"', ';', newlines). Paths also reject whitespace
+# (it would split a path into multiple `open` args); colors keep it, as ChimeraX
+# accepts multi-word names like "light gray".
 _CHIMERAX_UNSAFE_PATH_CHARS = ('"', ' ', '\t', ';', '\n', '\r')
+_CHIMERAX_UNSAFE_COLOR_CHARS = ('"', ';', '\n', '\r')
 
 
 def _validate_chimerax_path(path, role):
-    """Reject paths with characters that would break the ChimeraX --cmd script.
-
-    Real-world paths here are normally clean; this just surfaces a clear failure
-    instead of a silently broken or injected command.
-    """
-    text = str(path)
-    bad = [c for c in _CHIMERAX_UNSAFE_PATH_CHARS if c in text]
+    """Reject paths with characters that would break/inject the ChimeraX command."""
+    bad = [c for c in _CHIMERAX_UNSAFE_PATH_CHARS if c in str(path)]
     if bad:
         raise ValueError(
             f"{role} contains characters unsafe for the ChimeraX command "
-            f"script ({', '.join(repr(c) for c in bad)}): {text!r}"
+            f"script ({', '.join(repr(c) for c in bad)}): {path!r}"
+        )
+
+
+def _validate_chimerax_color(value, role):
+    """Reject colors with characters that would break/inject the ChimeraX command."""
+    bad = [c for c in _CHIMERAX_UNSAFE_COLOR_CHARS if c in str(value)]
+    if bad:
+        raise ValueError(
+            f"{role} contains characters unsafe for the ChimeraX command "
+            f"script ({', '.join(repr(c) for c in bad)}): {value!r}"
         )
 
 
@@ -173,8 +180,8 @@ def get_chimerax_command(chimerax_bin,
     # Validate before interpolating: values go unquoted into the --cmd script.
     _validate_chimerax_path(pdb_path, "PDB path")
     _validate_chimerax_path(attr_file_path, "attribute file path")
-    _validate_chimerax_path(non_mutated_color, "non-mutated color")
-    _validate_chimerax_path(text_color, "text color")
+    _validate_chimerax_color(non_mutated_color, "non-mutated color")
+    _validate_chimerax_color(text_color, "text color")
 
     chimerax_script = (
         f"open {pdb_path}; "

--- a/scripts/plotting/chimerax_plot.py
+++ b/scripts/plotting/chimerax_plot.py
@@ -136,6 +136,17 @@ def get_palette(intervals, type="diverging"):
         return f"{intervals[0]},#FFFFB2:{intervals[1]},#FECC5C:{intervals[2]},#FD8D3C:{intervals[3]},#F03B20:{intervals[4]},#BD0026"
 
 
+# Approximate fractional image width of one character in the 2dlabels font at
+# size 6 (empirically ~0.0136, near-constant across image sizes). Used to
+# horizontally centre a label instead of anchoring its left edge at a fixed x.
+_LABEL_CHAR_FRAC = 0.0136
+
+
+def _centered_xpos(text):
+    """Left x (image fraction) that horizontally centres `text` at x=0.5."""
+    return round(0.5 - len(text) * _LABEL_CHAR_FRAC / 2, 4)
+
+
 def get_chimerax_command(chimerax_bin,
                          pdb_path,
                          chimera_output_path,
@@ -172,8 +183,8 @@ def get_chimerax_command(chimerax_bin,
         f"open {attr_file_path}; "
         f"color byattribute {attribute} palette {palette}; "
         f"key {palette} :{intervals[0]} :{intervals[1]} :{intervals[2]} :{intervals[3]} :{intervals[4]} pos 0.35,0.03 fontSize 4 size 0.3,0.02;"
-        f"2dlabels create label text '{labels[attribute]}' size 6 color {text_color} xpos 0.34 ypos 0.065;"
-        f"2dlabels create title text '{gene} - {uni_id}-F{f} ' size 6 color {text_color} xpos 0.35 ypos 0.93;"
+        f"2dlabels create label text '{labels[attribute]}' size 6 color {text_color} xpos {_centered_xpos(labels[attribute])} ypos 0.065;"
+        f"2dlabels create title text '{gene} - {uni_id}-F{f}' size 6 color {text_color} xpos {_centered_xpos(f'{gene} - {uni_id}-F{f}')} ypos 0.93;"
         "hide atoms;"
         "show cartoons;"
         "lighting full;"
@@ -278,10 +289,10 @@ def generate_chimerax_plot(output_dir,
             pdb_candidates = [pdb_path_base, f"{pdb_path_base}.gz"]
             pdb_path = next((candidate for candidate in pdb_candidates if os.path.exists(candidate)), None)
             
-            labels = {"mutres" : "Mutations in residue ", 
-                      "mutvol" : "Mutations in volume ",
-                      "score" : "   Clustering score ",
-                      "logscore" : "log(Clustering score) "}
+            labels = {"mutres" : "Mutations in residue",
+                      "mutvol" : "Mutations in volume",
+                      "score" : "Clustering score",
+                      "logscore" : "log(Clustering score)"}
             cols = {"mutres" : "Mut_in_res", 
                     "mutvol" : "Mut_in_vol",
                     "score" : "Score_obs_sim",

--- a/tools/release/docker.sh
+++ b/tools/release/docker.sh
@@ -32,9 +32,9 @@ Save the Ubuntu 20.04 ChimeraX .deb installer (tested with v1.6.1) as:
 How to get it:
 
   External users:
-    The image needs an Ubuntu 20.04 build (= Debian 11 / Bullseye, matching the
-    image base; its executable is /usr/bin/chimerax). Download v1.6.1
-    (ucsf-chimerax_1.6.1ubuntu20.04_amd64.deb) from:
+    Use the Ubuntu 20.04 build: the Debian 11 (Bullseye) image base provides the
+    libssl1.1 + libffi7 it needs, and its executable lands at /usr/bin/chimerax.
+    Download v1.6.1 (ucsf-chimerax_1.6.1ubuntu20.04_amd64.deb) from:
       https://www.cgl.ucsf.edu/chimerax/older_releases.html
 
   BBGLab internal users:

--- a/tools/release/docker.sh
+++ b/tools/release/docker.sh
@@ -26,13 +26,16 @@ if [[ ! -f chimerax.deb ]]; then
     cat <<EOF >&2
 Missing chimerax.deb in repo root ($(pwd)).
 
-Save the Ubuntu 20.04 ChimeraX .deb installer as:
+Save the Ubuntu 20.04 ChimeraX .deb installer (tested with v1.6.1) as:
   $(pwd)/chimerax.deb
 
 How to get it:
 
   External users:
-    Download from https://www.cgl.ucsf.edu/chimerax/download.html
+    The image needs an Ubuntu 20.04 build (= Debian 11 / Bullseye, matching the
+    image base; its executable is /usr/bin/chimerax). Download v1.6.1
+    (ucsf-chimerax_1.6.1ubuntu20.04_amd64.deb) from:
+      https://www.cgl.ucsf.edu/chimerax/older_releases.html
 
   BBGLab internal users:
     Download from the lab cluster path:


### PR DESCRIPTION
Adds rendering options to `chimerax-plot` and polishes the default look. The 6-image filename set per gene is unchanged.

## New options
- `--spheres/--no-spheres` (default on) — sphere-highlight residues: mutated residues on the base plots, cluster residues on the `*_clusters` plots.
- `--cluster_markers` (default off) — translucent volume bubbles on cluster residues in the `*_clusters` plots.
- `--non_mutated_color` (default `gray`) and `--text_color` (default `black`).

## Default/appearance changes (note for existing users)
- `--transparent_bg` now defaults **on** (pass `--no-transparent_bg` for a white background).
- Cartoon lighting `soft → full`, silhouettes removed, title/label colour `darkred → black`.
- `*_clusters` plots now highlight cluster residues (not all mutated) and no longer draw bubbles by default — they're opt-in via `--cluster_markers`.
- Color-bar labels are right-justified (fixes the clipped last tick) and the title/label are centred.

## Other
- Validate paths/colours/label text interpolated into the `--cmd` script (prevents breakage/injection from odd gene symbols or values).
- Removed the temporary `--highlight` option in favour of the two flags above.

## Docs
- Documented the new options; corrected the snapshot description and the `--af_version` guidance (it's auto-detected, not normally set).
- Added a ChimeraX install note (tested with v1.6.1; `docker.sh` and the docs point to the exact `ucsf-chimerax_1.6.1ubuntu20.04_amd64.deb` from UCSF older releases).