### PR TITLE
docs: document tools/mut_profile and the optional mutation profile

### DIFF
--- a/docs/run_input_output.md
+++ b/docs/run_input_output.md
@@ -115,7 +115,7 @@ To compute the mutation profile with BGSignature two main files are required:
     - `CHROMOSOME`
     - `START`
     - `END`
-    - `ELEMENT`  
+    - `ELEMENT` (optional; not needed for the whole-genome `--collapse` workflow above, and not produced by the helper script below)
     
 ##### Create the Regions File  
 

--- a/docs/run_input_output.md
+++ b/docs/run_input_output.md
@@ -55,9 +55,9 @@ In this case:
 
 ### Mutation Profile
 
-The mutation profile of a cohort rapresents the count or the normalized frequencies of mutations in every possible k-nucleotide (e.g., trinucleotide or pentanucleotide) contexts.
+The mutation profile of a cohort represents the count or the normalized frequencies of mutations in every possible k-nucleotide (e.g., trinucleotide or pentanucleotide) contexts.
 
-It is optional: if not provided, Oncodrive3D uses a uniform distribution as the background model for simulating mutations and scoring clusters.
+It is optional: when omitted, Oncodrive3D falls back to a uniform background model for simulating mutations and scoring clusters, unless a site-level mutability table is supplied via `--mutability_config_path` (see [Mutability-aware runs](mutability.md)).
 
 The mutation profile used by Oncodrive3D is a dictionary (json file) including the frequency of mutations (*values*) of the cohort in 192 trinucleotide contexts (*keys*), normalized by the trinucleotide bias:
 

--- a/docs/run_input_output.md
+++ b/docs/run_input_output.md
@@ -57,6 +57,8 @@ In this case:
 
 The mutation profile of a cohort rapresents the count or the normalized frequencies of mutations in every possible k-nucleotide (e.g., trinucleotide or pentanucleotide) contexts.
 
+It is optional: if not provided, Oncodrive3D uses a uniform distribution as the background model for simulating mutations and scoring clusters.
+
 The mutation profile used by Oncodrive3D is a dictionary (json file) including the frequency of mutations (*values*) of the cohort in 192 trinucleotide contexts (*keys*), normalized by the trinucleotide bias:
 
 ```json

--- a/tools/mut_profile/README.md
+++ b/tools/mut_profile/README.md
@@ -1,0 +1,19 @@
+# Mutational profile helpers
+
+## `get_regions_file.py`
+
+Generates the genomic **regions file** (`CHROMOSOME`, `START`, `END` for the
+autosomes plus `X`/`Y`) needed to compute a cohort mutational profile.
+
+```bash
+python get_regions_file.py <genome> <kmer> > regions.tsv
+```
+
+- `<genome>`: one of `hg18`, `hg19`, `hg38`, `mm10`, `mm39`.
+- `<kmer>`: context width (e.g. `3` for trinucleotide). Each chromosome is
+  trimmed by `kmer // 2` at both ends so every position has full context.
+
+Requires [`bgreference`](https://pypi.org/project/bgreference/).
+
+See [Create the Mutation Profile with BGSignature](../../docs/run_input_output.md#create-the-mutation-profile-with-bgsignature)
+for how this file feeds into building the profile passed to `oncodrive3d run -p`.


### PR DESCRIPTION
- Adds a short README for `tools/mut_profile/get_regions_file.py` (purpose, usage, supported genomes), linking to the BGSignature workflow in `docs/run_input_output.md` for full context.
- Notes in `run_input_output.md` that the mutation profile is optional and that Oncodrive3D falls back to a uniform background model when it is omitted (previously only stated in the README).