### PR TITLE
fix(pipeline): restore SLURM executor under the test profile and harden Nextflow config

### DIFF
--- a/oncodrive3d_pipeline/conf/test.config
+++ b/oncodrive3d_pipeline/conf/test.config
@@ -19,25 +19,14 @@ params {
 
     indir = "${baseDir}/../test/input"
     outdir = "${baseDir}/../test/output"
-}
 
-process {
-    withName: 'ONCODRIVE3D:O3D_RUN' {
-        cpus     = 1
-        memory   = '4G'
-        time     = '2h'
-        maxForks = 1
-    }
-
-    withName: 'ONCODRIVE3D:O3D_PLOT' {
-        cpus   = 1
-        memory = '4G'
-        time   = '2h'
-    }
-
-    withName: 'ONCODRIVE3D:O3D_CHIMERAX_PLOT' {
-        cpus   = 1
-        memory = '4G'
-        time   = '2h'
-    }
+    // Keep the test light enough to run on a single-core login node.
+    // NB: process resources MUST be set via these params, not via a
+    // `process { withName: ... }` block here — the root `process` scope in
+    // nextflow.config is evaluated after this include and would override any
+    // per-process directives set here. Those params feed that root block
+    // (cpus = params.cores, memory = params.memory, maxForks = params.max_running).
+    cores       = 1
+    memory      = '4G'
+    max_running = 1
 }

--- a/oncodrive3d_pipeline/conf/test.config
+++ b/oncodrive3d_pipeline/conf/test.config
@@ -20,13 +20,14 @@ params {
     indir = "${baseDir}/../test/input"
     outdir = "${baseDir}/../test/output"
 
-    // Keep the test light enough to run on a single-core login node.
-    // NB: process resources MUST be set via these params, not via a
-    // `process { withName: ... }` block here — the root `process` scope in
-    // nextflow.config is evaluated after this include and would override any
-    // per-process directives set here. Those params feed that root block
-    // (cpus = params.cores, memory = params.memory, maxForks = params.max_running).
+    // Lightweight resources so the test runs on a single core. Set via params,
+    // NOT a `process { ... }` block here: such a block, pulled in by
+    // includeConfig, silently clobbers the process scope set in the `test`
+    // profile — including its `process.executor = 'slurm'`, which made the
+    // test fall back to the local executor (and ignore these caps).
     cores       = 1
     memory      = '4G'
     max_running = 1
+    plot_cores  = 1
+    plot_memory = '4G'
 }

--- a/oncodrive3d_pipeline/conf/test.config
+++ b/oncodrive3d_pipeline/conf/test.config
@@ -27,7 +27,7 @@ params {
     // test fall back to the local executor (and ignore these caps).
     cores       = 1
     memory      = '4G'
-    max_running = 1
+    max_running = 2     // the test has 2 cohorts; run them concurrently
     plot_cores  = 1
     plot_memory = '4G'
 }

--- a/oncodrive3d_pipeline/nextflow.config
+++ b/oncodrive3d_pipeline/nextflow.config
@@ -14,6 +14,13 @@ params {
     memory                = "70G"
     max_running           = 5
 
+    // Resources for the plotting stages (O3D_PLOT / O3D_CHIMERAX_PLOT)
+    plot_cores            = 4
+    plot_memory           = "24G"
+
+    // Process executor; use --executor local to run without a scheduler.
+    executor              = 'slurm'
+
     vep_input             = false
     mane                  = false
     ignore_mapping_issues = false
@@ -62,7 +69,7 @@ def singularity_binds = required_dirs.values()
 profiles {
 
     standard {
-        process.executor = 'slurm'
+        process.executor = params.executor
         singularity {
             enabled    = true
             autoMounts = true
@@ -71,7 +78,7 @@ profiles {
     }
 
     container {
-        process.executor = 'slurm'
+        process.executor = params.executor
         singularity {
             enabled    = true
             autoMounts = true
@@ -80,14 +87,14 @@ profiles {
     }
 
     conda {
-        process.executor    = 'slurm'
+        process.executor    = params.executor
         singularity.enabled = false
         conda.enabled       = true
         process.conda       = "${params.conda_env}"
     }
 
     test {
-        process.executor = 'slurm'
+        process.executor = params.executor
         includeConfig 'conf/test.config'
     }
 }
@@ -107,15 +114,15 @@ process {
     }
 
     withName: 'ONCODRIVE3D:O3D_PLOT' {
-        cpus     = 4
-        memory   = '24G'
+        cpus     = params.plot_cores as int
+        memory   = params.plot_memory
         time     = '24h'
         maxForks = params.max_running as int
     }
 
     withName: 'ONCODRIVE3D:O3D_CHIMERAX_PLOT' {
-        cpus     = 4
-        memory   = '24G'
+        cpus     = params.plot_cores as int
+        memory   = params.plot_memory
         time     = '24h'
         maxForks = params.max_running as int
     }
@@ -159,6 +166,6 @@ manifest {
     description     = "Oncodrive3D : Oncodrive3D is a method designed to analyse patterns of somatic mutations across tumors and normal tissues to identify three-dimensional clusters of missense mutations and detect genes that are under positive selection."
     mainScript      = 'main.nf'
     nextflowVersion = '!>=23.04.0'
-    version         = '1.0.8'
+    version         = '1.0.9'
     doi             = ''
 }

--- a/oncodrive3d_pipeline/validation.nf
+++ b/oncodrive3d_pipeline/validation.nf
@@ -18,6 +18,43 @@ def validatePaths(params) {
         }
     }
 
+    // Validate input directory and its expected sub-directories
+    if (!params.indir) {
+        error """
+        \u001B[31mERROR: Missing required parameter --indir.
+
+        Provide the input directory containing the mutation files and mutational
+        profiles, organised as:
+
+            <indir>/${params.vep_input ? 'vep' : 'maf'}/<cohort>${params.vep_input ? '.vep.tsv.gz' : '.in.maf'}
+            <indir>/mut_profile/<cohort>.sig.json
+
+        nextflow run main.nf --indir <input_folder>\u001B[0m
+        """
+    }
+
+    def inPath = file(params.indir)
+    if (!inPath.exists() || !inPath.isDirectory()) {
+        error """
+        \u001B[31mERROR: The specified input directory does not exist or is not a directory:
+        ${params.indir}\u001B[0m
+        """
+    }
+
+    def mutSubdir = params.vep_input ? 'vep' : 'maf'
+    [mutSubdir, 'mut_profile'].each { sub ->
+        def subPath = file("${params.indir}/${sub}")
+        if (!subPath.exists() || !subPath.isDirectory()) {
+            error """
+            \u001B[31mERROR: Expected sub-directory '${sub}/' not found under --indir:
+            ${params.indir}/${sub}
+
+            The input directory must contain '${mutSubdir}/' (mutation files) and
+            'mut_profile/' (mutational profiles).\u001B[0m
+            """
+        }
+    }
+
     // Validate Oncodrive3D datasets path
     def dataPath = file(params.data_dir)
     if (!dataPath.exists() || !dataPath.isDirectory()) {


### PR DESCRIPTION
Running the Nextflow pipeline with `-profile test,…` silently fell back to the **local executor** and ignored the test resource caps, so test jobs ran on the login node and O3D_RUN requested 10 cores / 70G — failing on constrained nodes with `Process requirement exceeds available CPUs -- req: 10; avail: 1`.

Root cause: `conf/test.config` carried its own `process { … }` block. Pulled in via `includeConfig`, that block clobbered the `process` scope set in the `test` profile — including `process.executor = 'slurm'` — so the executor defaulted to `local`. Verified with `nextflow config`: every profile resolved to `slurm` *except* `test,*`.

## Changes

- **conf/test.config**: drop the `process {}` block (the thing clobbering the executor); set test resources via params instead. Test now correctly resolves to `slurm` and applies its caps.
- **Plot stages**: make `O3D_PLOT` / `O3D_CHIMERAX_PLOT` resources param-driven (`plot_cores` / `plot_memory`) so they can be capped like `O3D_RUN`.
- **Executor**: configurable via `params.executor` (default `slurm`); allows `--executor local` for non-SLURM / CI runs.
- **Input validation**: `validatePaths` now checks `--indir` and its expected `maf/`|`vep/` + `mut_profile/` sub-directories with clear messages.
- **test profile**: `max_running = 2` so the two test cohorts run concurrently.
- Minor: use `\u001B` ANSI escapes in `validation.nf`; bump manifest to `1.0.9`.

## Verification

- `nextflow config` confirms `executor = 'slurm'` for all profiles incl. `test`.
- Confirmed on the cluster: `executor > slurm (2)`, both cohorts staged and run.