### PR TITLE
fix(run): skip genes whose contact map, sequence and missense-prob lengths disagree

### DIFF
--- a/docs/run_input_output.md
+++ b/docs/run_input_output.md
@@ -181,6 +181,7 @@ CSV file (`<cohort>.3d_clustering_genes.csv`) containing the results of the anal
 - `No_ID_mapping`: No corresponding UniProt ID is found for the given gene in the Oncodrive3D built datasets.
 - `Cmap_not_found`: The contact map for the gene's structural data is not available.
 - `Cmap_corrupted`: The contact map file exists but could not be loaded (e.g. empty or truncated from an interrupted build).
+- `Cmap_seq_mismatch`: The contact map size does not match the protein sequence length, indicating an inconsistent entry in the Oncodrive3D built datasets for that structure.
 - `Mut_not_in_structure`: The proportion of mutations mapped to positions outside the boundaries of the provided PDB structure exceeds the threshold for mapping issues (`--thr_mapping_issue`, default: `0.1`).
 - `WT_mismatch`: The proportion of mutations in the input file where the wild-type amino acid does not match the corresponding residue in the structural model exceeds the threshold for mapping issues (`--thr_mapping_issue`, default: `0.1`).
 - `Mut_with_zero_prob`: The proportion of mutations mapped to positions with a mutation probability of zero exceeds the threshold for mapping issues (`--thr_mapping_issue`, default: `0.1`).

--- a/scripts/run/clustering.py
+++ b/scripts/run/clustering.py
@@ -199,14 +199,6 @@ def clustering_3d(gene,
         result_gene_df["Status"] = "Cmap_not_found"
         return None, result_gene_df
 
-    # Skip if the contact map size disagrees with the sequence (inconsistent
-    # datasets entry).
-    if len(cmap) != len(seq_gene):
-        logger.warning(f"Length mismatch between contact map ({len(cmap)}) and sequence "
-                       f"({len(seq_gene)}) for {gene} ({uniprot_id}-F{af_f}): Skipping..")
-        result_gene_df["Status"] = "Cmap_seq_mismatch"
-        return None, result_gene_df
-
     # Load PAE
     pae_complete_path = f"{pae_path}/{uniprot_id}-F{af_f}-predicted_aligned_error.npy"
     if os.path.isfile(pae_complete_path):
@@ -222,6 +214,14 @@ def clustering_3d(gene,
         gene_miss_prob = np.array(miss_prob_dict[f"{uniprot_id}-F{af_f}"])
     else:
         gene_miss_prob = get_unif_gene_miss_prob(size=len(cmap))
+
+    # Skip if the contact map, sequence and missense-prob vector disagree in
+    # length (inconsistent datasets entry).
+    if not (len(cmap) == len(seq_gene) == len(gene_miss_prob)):
+        logger.warning(f"Length mismatch for {gene} ({uniprot_id}-F{af_f}) — cmap: {len(cmap)}, "
+                       f"seq: {len(seq_gene)}, miss_prob: {len(gene_miss_prob)}: Skipping..")
+        result_gene_df["Status"] = "Cmap_seq_mismatch"
+        return None, result_gene_df
 
     # Filter out genes whose missense prob vec include any NA
     if np.any(np.isnan(gene_miss_prob)):

--- a/scripts/run/clustering.py
+++ b/scripts/run/clustering.py
@@ -198,7 +198,15 @@ def clustering_3d(gene,
     else:
         result_gene_df["Status"] = "Cmap_not_found"
         return None, result_gene_df
-    
+
+    # Skip if the contact map size disagrees with the sequence (inconsistent
+    # datasets entry).
+    if len(cmap) != len(seq_gene):
+        logger.warning(f"Length mismatch between contact map ({len(cmap)}) and sequence "
+                       f"({len(seq_gene)}) for {gene} ({uniprot_id}-F{af_f}): Skipping..")
+        result_gene_df["Status"] = "Cmap_seq_mismatch"
+        return None, result_gene_df
+
     # Load PAE
     pae_complete_path = f"{pae_path}/{uniprot_id}-F{af_f}-predicted_aligned_error.npy"
     if os.path.isfile(pae_complete_path):


### PR DESCRIPTION
## What & why

A datasets inconsistency where the contact map, protein sequence and missense-probability vector for a gene don't share a length raised `ValueError: shapes (1405,1405) and (391,) not aligned` in `np.dot(cmap, gene_miss_prob)`. Because it fired inside the multiprocessing pool, it aborted the entire cohort, not just the offending gene. Seen on `LAWSON2020SCIENCE_BLADDER_LCM_WGS_ALLMUTS` with `Q9NXG0-F1` (CNTLN): `Seq`/cmap = 1405 but the `Seq_dna`-derived `miss_prob` = 391.

## Change

- `scripts/run/clustering.py`: after loading the missense-prob vector, skip the gene if `len(cmap) == len(seq) == len(gene_miss_prob)` does not hold — log a warning naming the gene/Uniprot-fragment and set `Status = Cmap_seq_mismatch`, matching the existing mapping-issue guards.
- `docs/run_input_output.md`: document the new `Cmap_seq_mismatch` status.

This is a defensive guard so one inconsistent datasets row can't take down a cohort; the root-cause fix in `build-datasets` is tracked separately.