### PR TITLE
fix(datasets): reliably drop UniProt entries with no length-matching transcript

### DIFF
--- a/docs/run_input_output.md
+++ b/docs/run_input_output.md
@@ -181,7 +181,7 @@ CSV file (`<cohort>.3d_clustering_genes.csv`) containing the results of the anal
 - `No_ID_mapping`: No corresponding UniProt ID is found for the given gene in the Oncodrive3D built datasets.
 - `Cmap_not_found`: The contact map for the gene's structural data is not available.
 - `Cmap_corrupted`: The contact map file exists but could not be loaded (e.g. empty or truncated from an interrupted build).
-- `Cmap_seq_mismatch`: The contact map size does not match the protein sequence length, indicating an inconsistent entry in the Oncodrive3D built datasets for that structure.
+- `Cmap_seq_mismatch`: The contact map size does not match the protein sequence length. This should not normally happen and points to a corrupted entry in the built datasets; consider rebuilding them.
 - `Mut_not_in_structure`: The proportion of mutations mapped to positions outside the boundaries of the provided PDB structure exceeds the threshold for mapping issues (`--thr_mapping_issue`, default: `0.1`).
 - `WT_mismatch`: The proportion of mutations in the input file where the wild-type amino acid does not match the corresponding residue in the structural model exceeds the threshold for mapping issues (`--thr_mapping_issue`, default: `0.1`).
 - `Mut_with_zero_prob`: The proportion of mutations mapped to positions with a mutation probability of zero exceeds the threshold for mapping issues (`--thr_mapping_issue`, default: `0.1`).

--- a/scripts/datasets/seq_for_mut_prob.py
+++ b/scripts/datasets/seq_for_mut_prob.py
@@ -320,6 +320,7 @@ def get_batch_exons_coord(batch_ids, ens_canonical_transcripts_lst):
 
         # Iterate throug the transcripts (starting from Ensembl canonical one if present)
         sorted_transcript_lst = get_sorted_transcript_lst(dic["gnCoordinate"], ens_canonical_transcripts_lst)
+        matched = False
         for i, ens_transcr_id in sorted_transcript_lst:
 
             ens_gene_id = dic["gnCoordinate"][i]["ensemblGeneId"]
@@ -339,19 +340,22 @@ def get_batch_exons_coord(batch_ids, ens_canonical_transcripts_lst):
                     end = exon["position"]["position"]
                 ranges.append((begin, end))
 
-            # Check if the DNA seq of the transcript is equal the codon lenght
+            # Keep the first transcript whose CDS length matches the protein
             start = 0 if not int(reverse_strand) else 1
             end = 1 if not int(reverse_strand) else 0
             len_dna = sum([coord[end] - coord[start] + 1 for coord in ranges])
             if len_dna / 3 == len(seq):
+                matched = True
                 break
-            # If there is no transcript with matching sequence length, return NA
-            elif i == len(dic["gnCoordinate"]) - 1:
-                ens_gene_id = np.nan
-                ens_transcr_id = np.nan
-                chromosome = np.nan
-                reverse_strand = np.nan
-                ranges = np.nan
+
+        # No length-matching transcript: drop the mapping so the entry
+        # falls back to Backtranseq (Reference_info -1) downstream
+        if not matched:
+            ens_gene_id = np.nan
+            ens_transcr_id = np.nan
+            chromosome = np.nan
+            reverse_strand = np.nan
+            ranges = np.nan
 
         lst_uni_id.append(uni_id)
         lst_ens_gene_id.append(ens_gene_id)


### PR DESCRIPTION
## What & why

`get_batch_exons_coord` checks each transcript's CDS length against the protein, but its "no transcript matched" fallback was keyed on `i == len(gnCoordinate)-1`. Since `get_sorted_transcript_lst` reorders transcripts (canonical first), `i` is the original index, not the loop position — so the fallback often never fired and a non-matching transcript's exon coords were left on the row. Result: `Seq`/cmap and `Seq_dna`/missense-prob disagree in length (e.g. Q9NXG0/CNTLN: Seq=1405, Seq_dna=391), which later crashes the run at `np.dot`. A scan of `datasets-260221` found 39 such rows / 18 proteins (incl. ING1, TRPM3); mouse and MANE-custom builds are clean.

## Change

- Use an explicit `matched` flag and null the mapping after the loop, so entries with no length-matching transcript fall back to Backtranseq (`Reference_info -1`) and get a length-consistent `Seq_dna`. `Seq` is always preserved.
- Clarify the `Cmap_seq_mismatch` status doc (shouldn't normally happen; points to a corrupted datasets entry).

Verified the real function on match / no-match-after-sort / empty cases.