### PR TITLE
docs: document pre-built Zenodo datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,13 @@ Python 3.10+ is required. Some systems also need a C/C++ toolchain:
 
 ## Building Datasets
 
-This step builds the datasets necessary for Oncodrive3D to run the 3D clustering analysis. It is required once after installation or whenever you need to generate datasets for a different organism or apply a specific threshold to define amino acid contacts.
+This step builds the datasets necessary for Oncodrive3D to run the 3D clustering analysis. It is required once after installation or whenever you need to generate datasets for a different organism or apply a specific threshold to define amino acid contacts. For common configurations, you can download pre-built datasets instead (see below).
+
+### Pre-built Datasets (download instead of building)
+
+Building the datasets locally is time- and resource-intensive. To skip it, you can download pre-built datasets and annotations for **Oncodrive3D v1.0.9** from [Zenodo](https://zenodo.org/records/21031511).
+
+### Building from Scratch
 
 > [!WARNING]
 > This step is time- and resource-intensive: it downloads and processes large amounts of structural data. Ensure adequate disk space, CPU, and a reliable internet connection (AlphaFold, Ensembl, Pfam, and other resources are fetched on demand).
@@ -194,6 +200,9 @@ Check the output in the `test/output/` directory to ensure the analysis complete
 ## Building Annotations & Plotting
 
 Oncodrive3D ships with an optional plotting pipeline: run `oncodrive3d build-annotations` once to cache structural/functional tracks, then use `oncodrive3d plot` and/or `chimerax-plot` to generate plots and tables that help interpret the clustering signal and distinguish real biology from artifacts.
+
+> [!TIP]
+> Pre-built annotations for Human and Mouse can be downloaded from [Zenodo](https://zenodo.org/records/21031511), letting you skip `build-annotations` for those organisms. The MANE datasets are not recommended for plotting, since MANE-associated structures often map to entries that lack UniProt annotations.
 
 See the [Annotation & plotting workflow](docs/annotations_plotting.md) for prerequisites, usage examples, and output descriptions.
 

--- a/docs/annotations_plotting.md
+++ b/docs/annotations_plotting.md
@@ -4,13 +4,16 @@ Oncodrive3D ships with a plotting pipeline that turns the clustering results int
 
 Annotations are built once per dataset via `oncodrive3d build-annotations`, then reused by `oncodrive3d plot` for any cohort.
 
+> [!TIP]
+> Pre-built annotations for **Human** and **Mouse** are available on [Zenodo](https://zenodo.org/records/21031511), paired with the matching pre-built datasets. If you download them you can skip the `build-annotations` step entirely and go straight to [Generating Plots](#generating-plots). Annotations are not provided for the MANE group: MANE-associated structures often map to entries that lack UniProt annotations, so the MANE datasets are not recommended for the plotting workflow. Use the standard Human datasets for plots.
+
 ---
 
 ## Prerequisites
 
 Building the annotation bundle (`oncodrive3d build-annotations`) is the demanding step and needs all of the following. Plotting (`oncodrive3d plot`) needs only items 1 and 2, plus the annotation bundle and the outputs of an `oncodrive3d run` (listed under [Generating Plots](#generating-plots)).
 
-1. **Datasets** – `oncodrive3d build-datasets` (or `build-datasets --mane_only`) must have been run already. Both steps read from this folder (`build-annotations` uses `pdb_structures` and `seq_for_mut_prob.tsv`; `plot` uses `confidence.tsv` and `seq_for_mut_prob.tsv`).
+1. **Datasets** – `oncodrive3d build-datasets` (or `build-datasets --mane_only`) must have been run already, or the pre-built datasets downloaded from Zenodo. Both steps read from this folder (`build-annotations` uses `pdb_structures` and `seq_for_mut_prob.tsv`; `plot` uses `confidence.tsv` and `seq_for_mut_prob.tsv`).
 2. **Python environment** – use the same environment (e.g., `uv` virtualenv) that you rely on for the CLI.
 3. **PDB_Tool binary** – `oncodrive3d build-annotations` invokes the [PDB_Tool](https://github.com/realbigws/PDB_Tool) executable named `PDB_Tool` on `$PATH` to compute per-residue solvent accessibility and secondary structure. See **Installing PDB_Tool** below for a recipe.
 4. **Internet access** – required to download Pfam annotations, UniProt features, and (unless `--ddg_dir` is set) RaSP ΔΔG predictions.
@@ -93,7 +96,7 @@ Once you have:
 - Processed mutations (`<cohort>.mutations.processed.tsv`),
 - Missense probability dictionary (`<cohort>.miss_prob.processed.json`),
 - Processed sequence dataframe (`<cohort>.seq_df.processed.tsv`),
-- Built datasets (`datasets/`) and annotations (`annotations/`),
+- Datasets (`datasets/`) and annotations (`annotations/`), built or downloaded,
 
 call:
 

--- a/docs/build_output.md
+++ b/docs/build_output.md
@@ -1,6 +1,6 @@
 # Building Datasets Output
 
-After `oncodrive3d build-datasets` completes, the build folder contains:
+After `oncodrive3d build-datasets` completes (or after extracting the pre-built datasets [from Zenodo](https://zenodo.org/records/21031511)), the build folder contains:
 
 ```text
 <build_folder>/

--- a/oncodrive3d_pipeline/README.md
+++ b/oncodrive3d_pipeline/README.md
@@ -29,7 +29,7 @@ Run a test to ensure that everything is set up correctly and functioning as expe
 nextflow run main.nf -profile test,container --data_dir <build_folder>
 ```
 
-Replace `<build_folder>` with the path to the Oncodrive3D datasets built in the [building datasets](../README.md#building-datasets) step.
+Replace `<build_folder>` with the path to the Oncodrive3D datasets built in the [building datasets](../README.md#building-datasets) step (or downloaded from Zenodo, as described there).
 If you prefer to use Conda, replace `container` in the `-profile` argument with `conda`.
 
 ## Usage
@@ -78,7 +78,7 @@ See [`nextflow.config`](nextflow.config) for the full parameter list and default
 
 ### Optional modules
 
-- `--plot true` – runs the same plotting workflow described in [docs/annotations_plotting.md](../docs/annotations_plotting.md). Requires a pre-built annotations folder (`--annotations_dir`) generated via `oncodrive3d build-annotations`. The pipeline publishes summary plots, per-gene panels, annotated CSVs, UniProt feature tables, and association plots under `${outdir}/${outsubdir}/`.
+- `--plot true` – runs the same plotting workflow described in [docs/annotations_plotting.md](../docs/annotations_plotting.md). Requires a pre-built annotations folder (`--annotations_dir`) generated via `oncodrive3d build-annotations` (or downloaded from [Zenodo](https://zenodo.org/records/21031511) for Human and Mouse). The pipeline publishes summary plots, per-gene panels, annotated CSVs, UniProt feature tables, and association plots under `${outdir}/${outsubdir}/`.
 - `--chimerax_plot true` – submits the optional `oncodrive3d chimerax-plot` step for each processed cohort (see [docs/annotations_plotting.md#chimerax-3d-snapshots](../docs/annotations_plotting.md#chimerax-3d-snapshots)). Ensure the `chimerax` binary is accessible inside the container/Conda env or set `process.ext.args` for `O3D_CHIMERAX_PLOT` (in `nextflow.config`) to include `--chimerax_bin /path/to/ChimeraX` if you need a custom location.
 
 ### Mutability-aware runs


### PR DESCRIPTION
Add download-instead-of-build guidance pointing to the public Zenodo record (https://zenodo.org/records/21031511) so users can skip the heavy `build-datasets` / `build-annotations` step.